### PR TITLE
Repository owner now has default access.

### DIFF
--- a/src/com/gitblit/models/UserModel.java
+++ b/src/com/gitblit/models/UserModel.java
@@ -44,7 +44,8 @@ public class UserModel implements Principal, Serializable, Comparable<UserModel>
 	}
 
 	public boolean canAccessRepository(String repositoryName) {
-		return canAdmin || repositories.contains(repositoryName.toLowerCase());
+		RepositoryModel repository = GitBlit.self().getRepositoryModel(repositoryName);
+		return canAdmin || repositories.contains(repositoryName.toLowerCase()) || repository.owner.equalsIgnoreCase(username);
 	}
 
 	public void addRepository(String name) {


### PR DESCRIPTION
There is no need to give repository owner separate access. Like an admin account, they will have access over their repositories.
