### PR TITLE
Service installation under centos

### DIFF
--- a/distrib/gitblit-centos
+++ b/distrib/gitblit-centos
@@ -1,0 +1,46 @@
+#!/bin/bash
+# chkconfig: 3 21 91
+# Source function library.
+. /etc/init.d/functions
+
+# change theses values (default values)
+GITBLIT_PATH=/opt/gitblit
+GITBLIT_HTTP_PORT=0
+GITBLIT_HTTPS_PORT=8443
+JAVA="java -server -Xmx1024M -jar"
+
+RETVAL=0
+
+case "$1" in
+  start)
+    if [ -f $GITBLIT_PATH/gitblit.jar ];
+      then
+      echo $"Starting gitblit server"
+      $JAVA $GITBLIT_PATH/gitblit.jar --httpsPort $GITBLIT_HTTPS_PORT --httpPort $GITBLIT_HTTP_PORT > /dev/null &
+      echo "."
+      exit $RETVAL
+    fi
+  ;;
+
+  stop)
+    if [ -f $GITBLIT_PATH/gitblit.jar ];
+      then
+      echo $"Starting gitblit server"
+      $JAVA $GITBLIT_PATH/gitblit.jar --stop > /dev/null &
+      echo "."
+      exit $RETVAL
+    fi
+  ;;
+  
+  force-reload|restart)
+      $0 stop
+      $0 start
+  ;;
+
+  *)
+    echo $"Usage: /etc/init.d/gitblit {start|stop|restart|force-reload}"
+    exit 1
+  ;;
+esac
+
+exit $RETVAL

--- a/distrib/install-service-centos.sh
+++ b/distrib/install-service-centos.sh
@@ -1,0 +1,3 @@
+cp gitblit-centos /etc/init.d/gitblit
+chmod +x /etc/init.d/gitblit
+sudo chkconfig --add gitblit


### PR DESCRIPTION
Hi,

The script "install-service.sh" and his service "gitblit" are not-compatible with CentOS.

I fork them under "*-centos" names and tested on CentOS 6.0 final.

Regards,
Romain
