### PR TITLE
Fix for issue 51.

### DIFF
--- a/src/com/gitblit/utils/JGitUtils.java
+++ b/src/com/gitblit/utils/JGitUtils.java
@@ -340,7 +340,7 @@ public class JGitUtils {
 					String repository = StringUtils.getRelativePath(basePath,
 							file.getAbsolutePath());
 					list.add(repository);
-				} else if (searchSubfolders) {
+				} else if (searchSubfolders && file.canRead()) {
 					// look for repositories in subfolders
 					list.addAll(getRepositoryList(basePath, file, exportAll, searchSubfolders));
 				}


### PR DESCRIPTION
Changed JGitUtils.java to not traverse unaccessible subfolders (issue 51).
This by checking if the folder is readable for the user running the gitblit server.
If the folder isn't readable, there is no sense in progressing further down the line.
