### PR TITLE
Fixes chkconfig for centos / rhel service installations.

### DIFF
--- a/distrib/gitblit-centos
+++ b/distrib/gitblit-centos
@@ -1,5 +1,6 @@
 #!/bin/bash
 # chkconfig: 3 21 91
+# description: Starts and Stops gitblit
 # Source function library.
 . /etc/init.d/functions
 


### PR DESCRIPTION
Running install-service-centos.sh was failing since the gitblit-centos had a missing description attribute.

```
$ chkconfig --add gitblit
service gitblit does not support chkconfig
```

Adding the description attribute resolves this issue.
