### PR TITLE
Display Name / Email for LDAP (PlaceHolders)

### DIFF
--- a/distrib/gitblit.properties
+++ b/distrib/gitblit.properties
@@ -221,6 +221,28 @@ realm.ldap.groupMemberPattern = (&(objectClass=group)(member=${dn}))
 # SINCE 1.0.0
 realm.ldap.admins= @Git_Admins
 
+# Attribute(s) on the USER record that indicate their display (or full) name. Leave blank
+# for no mapping available in LDAP
+#
+# This may be a single attribute, or a string of multiple attributes.  Examples:
+#  displayName - Uses the attribute 'displayName' on the user record
+#  ${personalTitle}. ${givenName} ${surname} - Will concatenate the 3 
+#       attributes together, with a '.' after personalTitle 
+#
+# SINCE 1.0.0
+realm.ldap.displayName= displayName
+
+# Attribute(s) on the USER record that indicate their email address.  Leave blank
+# for no mapping available in LDAP
+#
+# This may be a single attribute, or a string of multiple attributes.  Examples:
+#  email - Uses the attribute 'email' on the user record
+#  ${givenName}.${surname}@gitblit.com -Will concatenate the 2 attributes
+#       together with a '.' and '@' creating something like first.last@gitblit.com 
+#
+# SINCE 1.0.0
+realm.ldap.email = email
+
 #
 # Gitblit Web Settings
 #

--- a/src/com/gitblit/models/UserModel.java
+++ b/src/com/gitblit/models/UserModel.java
@@ -37,6 +37,8 @@ public class UserModel implements Principal, Serializable, Comparable<UserModel>
 	// field names are reflectively mapped in EditUser page
 	public String username;
 	public String password;
+	public String displayName;
+	public String emailAddress;
 	public boolean canAdmin;
 	public boolean excludeFromFederation;
 	public final Set<String> repositories = new HashSet<String>();

--- a/tests/com/gitblit/tests/resources/ldapUserServiceSampleData.ldif
+++ b/tests/com/gitblit/tests/resources/ldapUserServiceSampleData.ldif
@@ -62,6 +62,11 @@ objectClass: user
 objectClass: person
 sAMAccountName: UserOne
 userPassword: userOnePassword
+displayName: User One
+givenName: User
+surname: One
+personalTitle: Mr
+email: userone@gitblit.com
 memberOf: CN=Git_Admins,OU=Groups,OU=UserControl,OU=MyOrganization,DC=MyDomain
 memberOf: CN=Git_Users,OU=Groups,OU=UserControl,OU=MyOrganization,DC=MyDomain
 
@@ -70,6 +75,11 @@ objectClass: user
 objectClass: person
 sAMAccountName: UserTwo
 userPassword: userTwoPassword
+displayName: User Two
+givenName: User
+surname: Two
+personalTitle: Mr
+email: usertwo@gitblit.com
 memberOf: CN=Git_Users,OU=Groups,OU=UserControl,OU=MyOrganization,DC=MyDomain
 memberOf: CN=Git Admins,OU=Groups,OU=UserControl,OU=MyOrganization,DC=MyDomain
 
@@ -78,6 +88,11 @@ objectClass: user
 objectClass: person
 sAMAccountName: UserThree
 userPassword: userThreePassword
+displayName: User Three
+givenName: User
+surname: Three
+personalTitle: Mrs
+email: userthree@gitblit.com
 memberOf: CN=Git_Users,OU=Groups,OU=UserControl,OU=MyOrganization,DC=MyDomain
 
 dn: CN=UserFour,OU=Canada,OU=Users,OU=UserControl,OU=MyOrganization,DC=MyDomain
@@ -85,4 +100,9 @@ objectClass: user
 objectClass: person
 sAMAccountName: UserFour
 userPassword: userFourPassword
+displayName: User Four
+givenName: User
+surname: Four
+personalTitle: Miss
+email: userfour@gitblit.com
 memberOf: CN=Git_Users,OU=Groups,OU=UserControl,OU=MyOrganization,DC=MyDomain


### PR DESCRIPTION
Hi-

I've added some additional code to get the display name / email from LDAP in a nice, flexible manner (see documentation in gitblit.properties).  

Also, I've added some code to escape the user name - as it was allowing for LDAP injection attacks.  Please see the test case for an example of what the user could type to bypass authentication (only if passwords are stored in LDAP as clear text - unlikely, but possible).
