### PR TITLE
Java Proxy Configuration for working inside a company network behind a proxy 

### DIFF
--- a/distrib/gitblit
+++ b/distrib/gitblit
@@ -5,7 +5,8 @@ set -e
 GITBLIT_PATH=/opt/gitblit
 GITBLIT_HTTP_PORT=0
 GITBLIT_HTTPS_PORT=8443
-JAVA="java -server -Xmx1024M -jar"
+source ${GITBLIT_PATH}/java-proxy-config.sh
+JAVA="java -server -Xmx1024M ${JAVA_PROXY_CONFIG} -Djava.awt.headless=true -jar"
 
 . /lib/lsb/init-functions
 

--- a/distrib/gitblit-centos
+++ b/distrib/gitblit-centos
@@ -8,7 +8,8 @@
 GITBLIT_PATH=/opt/gitblit
 GITBLIT_HTTP_PORT=0
 GITBLIT_HTTPS_PORT=8443
-JAVA="java -server -Xmx1024M -jar"
+source ${GITBLIT_PATH}/java-proxy-config.sh
+JAVA="java -server -Xmx1024M ${JAVA_PROXY_CONFIG} -Djava.awt.headless=true -jar"
 
 RETVAL=0
 

--- a/distrib/gitblit-ubuntu
+++ b/distrib/gitblit-ubuntu
@@ -9,7 +9,8 @@ PATH=/sbin:/bin:/usr/bin:/usr/sbin
 # change theses values (default values)
 GITBLIT_PATH=/opt/gitblit
 GITBLIT_USER="gitblit"
-ARGS="-server -Xmx1024M -jar gitblit.jar"
+source ${GITBLIT_PATH}/java-proxy-config.sh
+ARGS="-server -Xmx1024M ${JAVA_PROXY_CONFIG} -Djava.awt.headless=true -jar gitblit.jar"
 
 RETVAL=0
 

--- a/distrib/java-proxy-config.sh
+++ b/distrib/java-proxy-config.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# To set the proxy configuration, specify the following host name and port
+#PROXY_HOST=
+#PROXY_PORT=
+
+# To exclude any hosts from proxy configuration such that they directly accessed by Gitblit without passing through the proxy server, append the host name to the following variable using "|" as the separator
+NON_PROXY_HOSTS="localhost|127.0.0.*|*.local|192.168.*.*|10.193.*.*"
+
+### The following should not need to be modified
+
+JAVA_PROXY_CONFIG=""
+
+if [ -n "${PROXY_HOST}" -a -n "${PROXY_PORT}" ]; then
+
+    JAVA_PROXY_CONFIG=" -DproxySet=true -Dhttp.proxyHost=${PROXY_HOST} -Dhttp.proxyPort=${PROXY_PORT} -Dhttps.proxyHost=${PROXY_HOST} -Dhttps.proxyPort=${PROXY_PORT} -Dftp.proxyHost=${PROXY_HOST} -Dftp.proxyPort=${PROXY_PORT} "
+fi
+
+if [ -n "${PROXY_HOST}" -a -n "${PROXY_PORT}" -a -n "${NON_PROXY_HOSTS}" ]; then
+
+    JAVA_PROXY_CONFIG="${JAVA_PROXY_CONFIG} -Dhttp.nonProxyHosts=\"${NON_PROXY_HOSTS}\" -Dftp.nonProxyHosts=\"${NON_PROXY_HOSTS}\" "
+fi
+
+export JAVA_PROXY_CONFIG
+


### PR DESCRIPTION
This is to make it easier to run inside a company network behind a proxy

Added a script (java-proxy-config.sh) to facilitate setting the proxy host and port and no proxy hosts, and then it concatenates all the java system properties for setting the java proxy configurations and puts the resulting string in an environment variable JAVA_PROXY_CONFIG

Modified the scirpts gitblit,  gitblit-ubuntu, and gitblit-centos to source the java-proxy-config.sh script and then include the resulting java proxy configuration in the java command

And also added "-Djava.awt.headless=true" to gitblit, gitblit-ubuntu, and gitblit-centos 
