### PR TITLE
Credential string split fix

### DIFF
--- a/src/com/gitblit/AuthenticationFilter.java
+++ b/src/com/gitblit/AuthenticationFilter.java
@@ -103,7 +103,7 @@ public abstract class AuthenticationFilter implements Filter {
 			String credentials = new String(Base64.decode(base64Credentials),
 					Charset.forName("UTF-8"));
 			// credentials = username:password
-			final String[] values = credentials.split(":");
+			final String[] values = credentials.split(":",2);
 
 			if (values.length == 2) {
 				String username = values[0];


### PR DESCRIPTION
Added a limit on the split to work around passwords that contain colons.
