### PR TITLE
StartTLS is not supported in LdapUserService (issue 122)

### DIFF
--- a/distrib/gitblit.properties
+++ b/distrib/gitblit.properties
@@ -797,6 +797,8 @@ federation.sets =
 #
 
 # URL of the LDAP server.
+# To use encrypted transport, use either ldaps:// URL for SSL or ldap+tls:// to
+# send StartTLS command.
 #
 # SINCE 1.0.0
 realm.ldap.server = ldap://localhost


### PR DESCRIPTION
By providing an URL in the format "ldap+tls://ldapserver.example.com",
you can now connect to LDAP servers that require StartTLS command.

See http://code.google.com/p/gitblit/issues/detail?id=122

P.S: I was not able to execute JUnit tests, they also do not work without my patch (do I need an LDAP server on localhost with the expected structure?). So forgive me, if sth. went wrong - but this code works with our OpenLDAP server.
