### PR TITLE
moved git clone syntax help to properties file

### DIFF
--- a/distrib/gitblit.properties
+++ b/distrib/gitblit.properties
@@ -192,6 +192,40 @@ git.streamFileThreshold = 50m
 # RESTART REQUIRED
 git.packedGitMmap = false
 
+
+# Help clone syntax to show on newly created repository (Empty Repository page)
+# {0} = repository url : http://localhost:8080/gitblit/git/example.git
+# {1} = repository name : example.git
+#
+# e.g. git clone {0}
+#
+# RESTART REQUIRED
+# SINCE 1.2.0
+git.cloneSyntax = git clone {0}
+
+
+# Help remote syntax to show on newly created repository (Empty Repository page)
+# {0} = repository url : http://localhost:8080/gitblit/git/example.git
+# {1} = repository name : example.git
+#
+# e.g. git remote add origin {0}
+#
+# RESTART REQUIRED
+# SINCE 1.2.0
+git.remoteSyntax = git remote add gitblit {0}
+
+
+# Help push syntax to show on newly created repository (Empty Repository page)
+# {0} = repository url : http://localhost:8080/gitblit/git/example.git
+# {1} = repository name : example.git
+#
+# e.g. git push origin master
+#
+# RESTART REQUIRED
+# SINCE 1.2.0
+git.pushSyntax = git push gitblit master
+
+
 #
 # Groovy Integration
 #

--- a/src/com/gitblit/wicket/pages/EmptyRepositoryPage.html
+++ b/src/com/gitblit/wicket/pages/EmptyRepositoryPage.html
@@ -30,6 +30,7 @@
 		<span style="padding-bottom:5px;">If you already have a local Git repository with commits, then you may add this repository as a remote and push to it.</span>
 		<p></p>
 		<pre wicket:id="remoteSyntax" style="padding: 5px 30px;"></pre>
+		<pre wicket:id="pushSyntax" style="padding: 5px 30px;"></pre>
 		<p></p>
 		<h3>Learn Git</h3>
 		If you are unsure how to use this information, consider reviewing the <a href="http://book.git-scm.com">Git Community Book</a> or <a href="http://progit.org/book" target="_blank">Pro Git</a> for a better understanding on how to use Git.

--- a/src/com/gitblit/wicket/pages/EmptyRepositoryPage.java
+++ b/src/com/gitblit/wicket/pages/EmptyRepositoryPage.java
@@ -56,9 +56,15 @@ public class EmptyRepositoryPage extends RootPage {
 		repositoryUrls.addAll(GitBlit.self().getOtherCloneUrls(repositoryName));
 		
 		String primaryUrl = ArrayUtils.isEmpty(repositoryUrls) ? "" : repositoryUrls.get(0);
+
+		String pushSyntax   = GitBlit.getString(Keys.git.pushSyntax, "git clone {0}");
+		String cloneSyntax  = GitBlit.getString(Keys.git.cloneSyntax, "git remote add gitblit {0}");
+		String remoteSyntax = GitBlit.getString(Keys.git.remoteSyntax, "git push gitblit master");
+
 		add(new Label("repository", repositoryName));
 		add(new RepositoryUrlPanel("pushurl", primaryUrl));
-		add(new Label("cloneSyntax", MessageFormat.format("git clone {0}", repositoryUrls.get(0))));
-		add(new Label("remoteSyntax", MessageFormat.format("git remote add gitblit {0}\ngit push gitblit master", primaryUrl)));
+		add(new Label("cloneSyntax",  MessageFormat.format(cloneSyntax, repositoryUrls.get(0), repositoryName)));
+		add(new Label("remoteSyntax", MessageFormat.format(remoteSyntax, primaryUrl, repositoryName)));
+		add(new Label("pushSyntax",   MessageFormat.format(pushSyntax,  repositoryUrls.get(0), repositoryName)));
 	}
 }


### PR DESCRIPTION
Moved syntax help line to properties file.  The lines that display clone,remote, push syntax help. e.g :
git clone http://example.com:8080/gitblit/git/project.git
git remote add gitblit http://example.com:8080/gitblit/git/project.git
git push gitblit master

I was importing a large number of projects today and it was frustrating not been alb to change gitblit to origin.  There was a lot of coping and pasting = ).

Thank you,

Ricardo
