### PR TITLE
Allows integration of GitBlit as plug-in in other projects.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -14,9 +14,12 @@
 	<property name="project.build.dir" value="${basedir}/build" />
 	<property name="project.deploy.dir" value="${basedir}/deploy" />
 	<property name="project.war.dir" value="${basedir}/war" />
+	<property name="project.jar.dir" value="${basedir}/jar" />
 	<property name="project.site.dir" value="${basedir}/site" />
 	<property name="project.resources.dir" value="${basedir}/resources" />	
 	<property name="project.express.dir" value="${basedir}/express" />
+	<property name="project.maven.repo.url" value="enter here your Maven repo URL" />
+	<property name="project.maven.repo.id" value="gitblit.maven.repo" />
 	<available property="hasBuildProps" file="${basedir}/build.properties"/>
 
 	<!--
@@ -85,6 +88,8 @@
 		</loadfile>	
 		<property name="distribution.zipfile" value="gitblit-${gb.version}.zip" />
 		<property name="distribution.warfile" value="gitblit-${gb.version}.war" />
+		<property name="distribution.jarfile" value="gitblit-${gb.version}.jar" />
+		<property name="distribution.pomfile" value="${basedir}/pom.xml" />
 		<property name="fedclient.zipfile" value="fedclient-${gb.version}.zip" />
 		<property name="manager.zipfile" value="manager-${gb.version}.zip" />
 		<property name="gbapi.zipfile" value="gbapi-${gb.version}.zip" />
@@ -441,6 +446,66 @@
 	</target>
 
 	
+	<!--
+		~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+		Build Gitblit JAR for usage in other projects plug-ins (i.e. Gerrit)
+		~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	-->
+	<target name="buildJAR" depends="compile" description="Build Gitblit JAR">
+
+		<echo>Building Gitblit JAR ${gb.version}</echo>
+
+		<delete dir="${project.jar.dir}" />
+
+		<!-- Gitblit classes -->
+		<mkdir dir="${project.jar.dir}"/>
+		<copy todir="${project.jar.dir}">
+			<fileset dir="${project.build.dir}">
+				<exclude name="WEB-INF/" />
+				<exclude name="com/gitblit/tests/" />
+				<exclude name="com/gitblit/build/**" />
+				<exclude name="com/gitblit/client/**" />
+				<exclude name="com/gitblit/AddIndexedBranch*.class" />
+				<exclude name="com/gitblit/GitBlitServer*.class" />
+				<exclude name="com/gitblit/Launcher*.class" />
+				<exclude name="com/gitblit/MakeCertificate*.class" />
+			</fileset>
+		</copy>
+
+		<!-- Build the JAR file -->
+		<jar basedir="${project.jar.dir}" destfile="${distribution.jarfile}" compress="true" />
+	</target>
+
+	<!--
+		~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+		Install Gitblit JAR for usage as Maven module
+		~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	-->
+	<target name="installMaven" depends="buildJAR" description="Install Gitblit JAR as Maven module">
+		<exec executable="mvn">
+			<arg value="install:install-file" />
+			<arg value="-Dfile=${distribution.jarfile}" />
+			<arg value="-DpomFile=${distribution.pomfile}" />
+			<arg value="-DcreateChecksum=true" />
+		</exec>
+	</target>
+
+	<!--
+    	~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    	Upload Gitblit JAR to remote Maven repository
+    	~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    -->
+	<target name="uploadMaven" depends="buildJAR" description="Upload Gitblit JAR to remote Maven repository">
+		<exec executable="mvn">
+			<arg value="deploy:deploy-file" />
+			<arg value="-Dfile=${distribution.jarfile}" />
+			<arg value="-DpomFile=${distribution.pomfile}" />
+			<arg value="-Durl=${project.maven.repo.url}" />
+			<arg value="-DrepositoryId=${project.maven.repo.id}" />
+			<arg value="-DcreateChecksum=true" />
+		</exec>
+	</target>
+
 	<!-- 
 		~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 		Build the stand-alone, command-line Gitblit Federation Client

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,7 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+		<modelVersion>4.0.0</modelVersion>
+		<groupId>com.gitblit</groupId>
+		<artifactId>gitblit</artifactId>
+		<version>1.1.0</version>
+</project>

--- a/src/com/gitblit/models/UserModel.java
+++ b/src/com/gitblit/models/UserModel.java
@@ -138,4 +138,8 @@ public class UserModel implements Principal, Serializable, Comparable<UserModel>
 	public int compareTo(UserModel o) {
 		return username.compareTo(o.username);
 	}
+
+	public boolean canAccessBranch(RepositoryModel repositoryModel, String name) {
+		return true;
+	}
 }

--- a/src/com/gitblit/wicket/pages/BasePage.java
+++ b/src/com/gitblit/wicket/pages/BasePage.java
@@ -15,6 +15,7 @@
  */
 package com.gitblit.wicket.pages;
 
+import java.io.InputStream;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.ResourceBundle;
@@ -40,6 +41,8 @@ import org.apache.wicket.protocol.http.WebRequest;
 import org.apache.wicket.protocol.http.WebResponse;
 import org.apache.wicket.protocol.http.servlet.ServletWebRequest;
 import org.apache.wicket.request.RequestParameters;
+import org.apache.wicket.resource.ContextRelativeResource;
+import org.apache.wicket.util.resource.ResourceStreamNotFoundException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -65,14 +68,14 @@ public abstract class BasePage extends WebPage {
 		super();
 		logger = LoggerFactory.getLogger(getClass());
 		customizeHeader();
-		loginByCookie();
+		login();
 	}
 
 	public BasePage(PageParameters params) {
 		super(params);
 		logger = LoggerFactory.getLogger(getClass());
 		customizeHeader();
-		loginByCookie();
+		login();
 	}
 	
 	private void customizeHeader() {
@@ -116,16 +119,14 @@ public abstract class BasePage extends WebPage {
 		super.onAfterRender();
 	}	
 
-	private void loginByCookie() {
-		if (!GitBlit.getBoolean(Keys.web.allowCookieAuthentication, false)) {
-			return;
-		}
-		UserModel user = null;
-
-		// Grab cookie from Browser Session
+	private void login() {
 		Cookie[] cookies = ((WebRequest) getRequestCycle().getRequest()).getCookies();
-		if (cookies != null && cookies.length > 0) {
+		UserModel user = null;
+		if (GitBlit.self().allowCookieAuthentication() && cookies != null && cookies.length > 0) {
+			// Grab cookie from Browser Session
 			user = GitBlit.self().authenticate(cookies);
+		} else {
+			user = GitBlit.self().authenticate(((WebRequest) getRequestCycle().getRequest()).getHttpServletRequest());
 		}
 
 		// Login the user

--- a/src/com/gitblit/wicket/pages/RepositoriesPage.java
+++ b/src/com/gitblit/wicket/pages/RepositoriesPage.java
@@ -17,7 +17,6 @@ package com.gitblit.wicket.pages;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.text.MessageFormat;
@@ -154,8 +153,7 @@ public class RepositoriesPage extends RootPage {
 		}
 		String message;
 		try {			
-			ContextRelativeResource res = WicketUtils.getResource(file);
-			InputStream is = res.getResourceStream().getInputStream();
+		    InputStream is = GitBlit.self().getResourceAsStream(file);
 			InputStreamReader reader = new InputStreamReader(is, Constants.CHARACTER_ENCODING);
 			message = MarkdownUtils.transformMarkdown(reader);
 			reader.close();

--- a/src/com/gitblit/wicket/pages/RepositoryPage.java
+++ b/src/com/gitblit/wicket/pages/RepositoryPage.java
@@ -47,6 +47,7 @@ import com.gitblit.GitBlit;
 import com.gitblit.Keys;
 import com.gitblit.PagesServlet;
 import com.gitblit.SyndicationServlet;
+import com.gitblit.models.RefModel;
 import com.gitblit.models.RepositoryModel;
 import com.gitblit.models.SubmoduleModel;
 import com.gitblit.utils.ArrayUtils;
@@ -80,6 +81,19 @@ public abstract class RepositoryPage extends BasePage {
 		repositoryName = WicketUtils.getRepositoryName(params);
 		objectId = WicketUtils.getObject(params);
 		
+		if (objectId != null) {
+			RefModel branch = null;
+			if ((branch = JGitUtils.getBranch(getRepository(), objectId)) != null) {
+				boolean canAccess = GitBlitWebSession
+						.get()
+						.getUser()
+						.canAccessBranch(getRepositoryModel(),
+								branch.reference.getName());
+				if (!canAccess) {
+					error("Access denied", true);
+				}
+			}
+		}
 		if (StringUtils.isEmpty(repositoryName)) {
 			error(MessageFormat.format(getString("gb.repositoryNotSpecifiedFor"), getPageName()), true);
 		}


### PR DESCRIPTION
There are now three new targets on the ANT build:
- buildJAR: creates a GitBlit JAR including the GitBlit biz logic
- installMaven: install GitBlit JAR as Maven module
- uploadMaven: uploads GitBlit JAR to a Maven repository

Additional extensions have been made to allow:
a) GitBlit to load his resources outside of Wicket domain
b) GitBlit to use an injected UserService
c) Generic authentication of HTTP Request using 3rd party logic
d) Load settings programmatically from an InputStream
e) Use cookie authentication OR generic HTTP Request
   authentication for Wicket pages
f) UserModel with branch-level security logic
