### PR TITLE
Allow integration as plug-in with Gerrit Code Review (and potentially other ALMs)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@
 *.directory
 /.gradle
 /projects.conf
+/pom.xml

--- a/build.xml
+++ b/build.xml
@@ -14,9 +14,12 @@
 	<property name="project.build.dir" value="${basedir}/build" />
 	<property name="project.deploy.dir" value="${basedir}/deploy" />
 	<property name="project.war.dir" value="${basedir}/war" />
+	<property name="project.jar.dir" value="${basedir}/jar" />
 	<property name="project.site.dir" value="${basedir}/site" />
 	<property name="project.resources.dir" value="${basedir}/resources" />	
 	<property name="project.express.dir" value="${basedir}/express" />
+	<property name="project.maven.repo.url" value="enter here your Maven repo URL" />
+	<property name="project.maven.repo.id" value="gitblit.maven.repo" />
 	<available property="hasBuildProps" file="${basedir}/build.properties"/>
 
 	<!--
@@ -85,6 +88,8 @@
 		</loadfile>	
 		<property name="distribution.zipfile" value="gitblit-${gb.version}.zip" />
 		<property name="distribution.warfile" value="gitblit-${gb.version}.war" />
+		<property name="distribution.jarfile" value="gitblit-${gb.version}.jar" />
+		<property name="distribution.pomfile" value="${basedir}/pom.xml" />
 		<property name="fedclient.zipfile" value="fedclient-${gb.version}.zip" />
 		<property name="manager.zipfile" value="manager-${gb.version}.zip" />
 		<property name="gbapi.zipfile" value="gbapi-${gb.version}.zip" />
@@ -441,6 +446,76 @@
 	</target>
 
 	
+	<!--
+		~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+		Build Gitblit JAR for usage in other projects plug-ins (i.e. Gerrit)
+		~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	-->
+	<target name="buildJAR" depends="compile" description="Build Gitblit JAR">
+
+		<echo>Building Gitblit JAR ${gb.version}</echo>
+
+		<delete dir="${project.jar.dir}" />
+
+		<!-- Gitblit classes -->
+		<mkdir dir="${project.jar.dir}"/>
+		<copy todir="${project.jar.dir}">
+			<fileset dir="${project.build.dir}">
+				<exclude name="WEB-INF/" />
+				<exclude name="com/gitblit/tests/" />
+				<exclude name="com/gitblit/build/**" />
+				<exclude name="com/gitblit/client/**" />
+				<exclude name="com/gitblit/AddIndexedBranch*.class" />
+				<exclude name="com/gitblit/GitBlitServer*.class" />
+				<exclude name="com/gitblit/Launcher*.class" />
+				<exclude name="com/gitblit/MakeCertificate*.class" />
+			</fileset>
+		</copy>
+
+		<!-- Build the JAR file -->
+		<jar basedir="${project.jar.dir}" destfile="${distribution.jarfile}" compress="true" />
+	</target>
+
+	<!--
+		~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+		Build pom.xml for GitBlit JAR Maven module
+		~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	-->
+	<target name="buildMaven" depends="buildJAR" description="Build pom.xml for Gitblit JAR Maven module">
+		<copy tofile="${distribution.pomfile}" file="${distribution.pomfileTmplt}"/>
+		<replace file="${distribution.pomfile}" token="@gb.version@" value="${gb.version}" />
+	</target>
+
+	<!--
+		~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+		Install Gitblit JAR for usage as Maven module
+		~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	-->
+	<target name="installMaven" depends="buildMaven" description="Install Gitblit JAR as Maven module">
+		<exec executable="mvn">
+			<arg value="install:install-file" />
+			<arg value="-Dfile=${distribution.jarfile}" />
+			<arg value="-DpomFile=${distribution.pomfile}" />
+			<arg value="-DcreateChecksum=true" />
+		</exec>
+	</target>
+
+	<!--
+    	~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    	Upload Gitblit JAR to remote Maven repository
+    	~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    -->
+	<target name="uploadMaven" depends="buildJAR" description="Upload Gitblit JAR to remote Maven repository">
+		<exec executable="mvn">
+			<arg value="deploy:deploy-file" />
+			<arg value="-Dfile=${distribution.jarfile}" />
+			<arg value="-DpomFile=${distribution.pomfile}" />
+			<arg value="-Durl=${project.maven.repo.url}" />
+			<arg value="-DrepositoryId=${project.maven.repo.id}" />
+			<arg value="-DcreateChecksum=true" />
+		</exec>
+	</target>
+
 	<!-- 
 		~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 		Build the stand-alone, command-line Gitblit Federation Client

--- a/src/com/gitblit/models/UserModel.java
+++ b/src/com/gitblit/models/UserModel.java
@@ -217,7 +217,7 @@ public class UserModel implements Principal, Serializable, Comparable<UserModel>
 		return permission;
 	}
 	
-	private boolean canAccess(RepositoryModel repository, AccessRestrictionType ifRestriction, AccessPermission requirePermission) {
+	protected boolean canAccess(RepositoryModel repository, AccessRestrictionType ifRestriction, AccessPermission requirePermission) {
 		if (repository.accessRestriction.atLeast(ifRestriction)) {
 			AccessPermission permission = getRepositoryPermission(repository);
 			return permission.atLeast(requirePermission);
@@ -432,5 +432,10 @@ public class UserModel implements Principal, Serializable, Comparable<UserModel>
 			}
 		}
 		return nameVerified && emailVerified;
+	}
+	
+	public boolean hasBranchPermission(String repositoryName, String branch) {
+		// Default UserModel doesn't implement branch-level security. Other Realms (i.e. Gerrit) may override this method.
+		return hasRepositoryPermission(repositoryName);
 	}
 }

--- a/src/com/gitblit/wicket/pages/BasePage.java
+++ b/src/com/gitblit/wicket/pages/BasePage.java
@@ -76,14 +76,14 @@ public abstract class BasePage extends WebPage {
 		super();
 		logger = LoggerFactory.getLogger(getClass());
 		customizeHeader();
-		loginByCookie();
+		login();
 	}
 
 	public BasePage(PageParameters params) {
 		super(params);
 		logger = LoggerFactory.getLogger(getClass());
 		customizeHeader();
-		loginByCookie();
+		login();
 	}
 	
 	private void customizeHeader() {
@@ -127,16 +127,14 @@ public abstract class BasePage extends WebPage {
 		super.onAfterRender();
 	}	
 
-	private void loginByCookie() {
-		if (!GitBlit.getBoolean(Keys.web.allowCookieAuthentication, false)) {
-			return;
-		}
-		UserModel user = null;
-
-		// Grab cookie from Browser Session
+	private void login() {
 		Cookie[] cookies = ((WebRequest) getRequestCycle().getRequest()).getCookies();
-		if (cookies != null && cookies.length > 0) {
+		UserModel user = null;
+		if (GitBlit.self().allowCookieAuthentication() && cookies != null && cookies.length > 0) {
+			// Grab cookie from Browser Session
 			user = GitBlit.self().authenticate(cookies);
+		} else {
+			user = GitBlit.self().authenticate(((WebRequest) getRequestCycle().getRequest()).getHttpServletRequest());
 		}
 
 		// Login the user

--- a/src/com/gitblit/wicket/pages/RepositoriesPage.java
+++ b/src/com/gitblit/wicket/pages/RepositoriesPage.java
@@ -17,7 +17,6 @@ package com.gitblit.wicket.pages;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.text.MessageFormat;
@@ -154,8 +153,7 @@ public class RepositoriesPage extends RootPage {
 		}
 		String message;
 		try {			
-			ContextRelativeResource res = WicketUtils.getResource(file);
-			InputStream is = res.getResourceStream().getInputStream();
+		    InputStream is = GitBlit.self().getResourceAsStream(file);
 			InputStreamReader reader = new InputStreamReader(is, Constants.CHARACTER_ENCODING);
 			message = MarkdownUtils.transformMarkdown(reader);
 			reader.close();

--- a/src/com/gitblit/wicket/pages/RepositoryPage.java
+++ b/src/com/gitblit/wicket/pages/RepositoryPage.java
@@ -48,6 +48,7 @@ import com.gitblit.Keys;
 import com.gitblit.PagesServlet;
 import com.gitblit.SyndicationServlet;
 import com.gitblit.models.ProjectModel;
+import com.gitblit.models.RefModel;
 import com.gitblit.models.RepositoryModel;
 import com.gitblit.models.SubmoduleModel;
 import com.gitblit.models.UserModel;
@@ -91,6 +92,19 @@ public abstract class RepositoryPage extends BasePage {
 		}
 		objectId = WicketUtils.getObject(params);
 		
+		if (objectId != null) {
+			RefModel branch = null;
+			if ((branch = JGitUtils.getBranch(getRepository(), objectId)) != null) {
+				boolean canAccess = GitBlitWebSession
+						.get()
+						.getUser()
+						.hasBranchPermission(getRepositoryModel().name,
+								branch.reference.getName());
+				if (!canAccess) {
+					error("Access denied", true);
+				}
+			}
+		}
 		if (StringUtils.isEmpty(repositoryName)) {
 			error(MessageFormat.format(getString("gb.repositoryNotSpecifiedFor"), getPageName()), true);
 		}

--- a/tmplt.pom.xml
+++ b/tmplt.pom.xml
@@ -1,0 +1,7 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+		<modelVersion>4.0.0</modelVersion>
+		<groupId>com.gitblit</groupId>
+		<artifactId>gitblit</artifactId>
+		<version>@gb.version@</version>
+</project>


### PR DESCRIPTION
There are now three new targets on the ANT build:
- buildJAR: creates a GitBlit JAR including the GitBlit biz logic
- installMaven: install GitBlit JAR as Maven module
- uploadMaven: uploads GitBlit JAR to a Maven repository

Additional extensions have been made to allow:
a) GitBlit to load his resources outside of Wicket domain
b) GitBlit to use an injected UserService
c) Generic authentication of HTTP Request using 3rd party logic
d) Load settings programmatically from an InputStream
e) Use cookie authentication OR generic HTTP Request
   authentication for Wicket pages
f) UserModel with branch-level security logic
