### PR TITLE
Removed DoubleCheckedLocking from checkstyle.xml.

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -53,7 +53,6 @@
         </module>
         <module name="NeedBraces" />
         <module name="RightCurly" />
-        <module name="DoubleCheckedLocking" />
         <module name="EmptyStatement" />
         <module name="EqualsHashCode" />
         <module name="IllegalInstantiation" />


### PR DESCRIPTION
Since Checkstyle 5.6 it's no longer supported (see http://checkstyle.sourceforge.net/releasenotes.html)
