### PR TITLE
Allow Windows users to pass parameters

### DIFF
--- a/distrib/add-indexed-branch.cmd
+++ b/distrib/add-indexed-branch.cmd
@@ -17,4 +17,4 @@
 @SET FOLDER=c:/gitblit/git
 @SET EXCLUSIONS=--skip test.git --skip group/test*
 @SET BRANCH=default
-@java -cp gitblit.jar;"%CD%\ext\*" com.gitblit.AddIndexedBranch --repositoriesFolder %FOLDER% --branch %BRANCH% %EXCLUSIONS%
+@java -cp gitblit.jar;"%CD%\ext\*" com.gitblit.AddIndexedBranch --repositoriesFolder %FOLDER% --branch %BRANCH% %EXCLUSIONS% %*

--- a/distrib/authority.cmd
+++ b/distrib/authority.cmd
@@ -1,1 +1,1 @@
-@java -jar authority.jar --baseFolder data
+@java -jar authority.jar --baseFolder data %*

--- a/distrib/gitblit-stop.cmd
+++ b/distrib/gitblit-stop.cmd
@@ -1,1 +1,1 @@
-@java -jar gitblit.jar --stop --baseFolder data
+@java -jar gitblit.jar --stop --baseFolder data %*

--- a/distrib/gitblit.cmd
+++ b/distrib/gitblit.cmd
@@ -1,1 +1,1 @@
-@java -jar gitblit.jar --baseFolder data
+@java -jar gitblit.jar --baseFolder data %*


### PR DESCRIPTION
Hi James,

Excellent tool! I just started playing around with it, and I'm really impressed. I love how you've made Windows a first-class citizen.

I noticed, however, that gitblit did not pick up my command line arguments when I passed them to `gitblit.cmd` on Windows. I fixed this in this tiny pull request, by adding `%*` to the end of the line in all cmd files where I believe it _might_ make sense.
