### PR TITLE
Fix buildWAR target

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -277,7 +277,7 @@
 			<class name="com.gitblit.EnforceAuthenticationFilter" />
 			<class name="com.gitblit.FederationServlet" />
 			<class name="com.gitblit.GitFilter" />
-			<class name="com.gitblit.GitServlet" />
+			<class name="com.gitblit.git.GitServlet" />
 			<class name="com.gitblit.PagesFilter" />
 			<class name="com.gitblit.PagesServlet" />
 			<class name="com.gitblit.RobotsTxtServlet" />
@@ -385,7 +385,7 @@
 			<class name="com.gitblit.EnforceAuthenticationFilter" />
 			<class name="com.gitblit.FederationServlet" />
 			<class name="com.gitblit.GitFilter" />
-			<class name="com.gitblit.GitServlet" />
+			<class name="com.gitblit.git.GitServlet" />
 			<class name="com.gitblit.PagesFilter" />
 			<class name="com.gitblit.PagesServlet" />
 			<class name="com.gitblit.RobotsTxtServlet" />


### PR DESCRIPTION
Fist of all thank you for integrating JGut 3.0.0-SNAPSHOT! I wonder why line 163 in RepositoriesPage.java is failing to load welcome.mkd? It is in place in gerrit-gitblit.jar in root:

jar -tf gitblit.jar | grep -i welcome.mkd
welcome.mkd

Instead of welcome message i see this (from Gerit GitBlit Plugin):

Failed to read default message from welcome.mkd!

I am going to check the vanilla war and was trying to build it and it failed:

BUILD FAILED
/home/davido/projects/gitblit_src/build.xml:272: org.moxie.MoxieException: Unable to resolve: com/gitblit/GitServlet.class

com/gitblit/GitServlet.class could not be located on the classpath.

```
at org.moxie.ant.MxGenJar.execute(MxGenJar.java:405)
```

So i adjusted the path. Not sure if GitServlet.java should be moved?

Thanks
David
