### PR TITLE
Improve page title

### DIFF
--- a/src/main/java/com/gitblit/wicket/pages/BasePage.java
+++ b/src/main/java/com/gitblit/wicket/pages/BasePage.java
@@ -128,9 +128,9 @@ public abstract class BasePage extends SessionPage {
 
 	protected void setupPage(String repositoryName, String pageName) {
 		if (repositoryName != null && repositoryName.trim().length() > 0) {
-			add(new Label("title", getServerName() + " - " + repositoryName));
+			add(new Label("title", repositoryName + " - " + Keys.web.siteName));
 		} else {
-			add(new Label("title", getServerName()));
+			add(new Label("title", Keys.web.siteName));
 		}
 
 		ExternalLink rootLink = new ExternalLink("rootLink", urlFor(RepositoriesPage.class, null).toString());


### PR DESCRIPTION
- When viewing a repository, users want to know what repo they're
  on. Currently, it's usually pushed out of view
- Use siteName for the title instead of the server name
