### PR TITLE
fixed - params.branch parameter was not taking into account.

### DIFF
--- a/src/main/java/com/gitblit/AddIndexedBranch.java
+++ b/src/main/java/com/gitblit/AddIndexedBranch.java
@@ -92,7 +92,7 @@ public class AddIndexedBranch {
 				config.load();
 				
 				Set<String> indexedBranches = new LinkedHashSet<String>();
-				indexedBranches.add(Constants.DEFAULT_BRANCH);
+				indexedBranches.add(params.branch);
 				
 				String [] branches = config.getStringList("gitblit", null, "indexBranch");
 				if (!ArrayUtils.isEmpty(branches)) {


### PR DESCRIPTION
params.branch parameter was not used.
When adding a long list of Git repositories, only 'default' branch was added, even if I specified "--branch refs/heads/master" in parameter.
