### PR TITLE
Fixed markdown pages in gh-pages

### DIFF
--- a/src/main/java/com/gitblit/PagesServlet.java
+++ b/src/main/java/com/gitblit/PagesServlet.java
@@ -150,8 +150,9 @@ public class PagesServlet extends HttpServlet {
 			if (StringUtils.isEmpty(resource)) {
 				// find resource
 				List<String> markdownExtensions = GitBlit.getStrings(Keys.web.markdownExtensions);
-				List<String> extensions = new ArrayList<String>(markdownExtensions.size() + 1);
+				List<String> extensions = new ArrayList<String>(markdownExtensions.size() + 2);
 				extensions.add("html");
+				extensions.add("htm");
 				extensions.addAll(markdownExtensions);
 				for (String ext : extensions){
 					String file = "index." + ext;


### PR DESCRIPTION
Hi,

I'm newbie of Gitblit.
Thank you for the wonderful software!

I found 3 issues regarding markdown pages in gh-pages in the servlet class  "com.gitblit.PagesServlet".
- Can't provide index page other than "index.html"

Please see the line 152 of the servlet.

``` java
content = JGitUtils.getStringContent(r, tree, file, encodings)
                            .getBytes(Constants.ENCODING);
```

If the "file" doesn't exist, JGitUtils#getStringContent() returns null, and this causes NPE.
So the servlet can't provide other than the first file "index.html".
- Can't provide markdown files with "text/html" content type

Currently, content type is determined in the code 165-168.

``` java
                    String contentType = context.getMimeType(resource);
                    if (contentType == null) {
                        contentType = "text/plain";
                    }
```

In the case of "mkd", "md", "markdown" and so on, ServletContext#getMimeType() returns null then markdown files is provided with "text/plain" content type.
- Only  index.mkd is supported as default index page [ This is improvement ]

Default index page files were constants (index.html, index.htm, index.mkd).
User defined markdown extensions should be contained in these files.
