### PR TITLE
Fixes findbugs warning - dereferencing null in exception case

### DIFF
--- a/src/main/java/com/gitblit/LogoServlet.java
+++ b/src/main/java/com/gitblit/LogoServlet.java
@@ -87,7 +87,9 @@ public class LogoServlet extends HttpServlet {
 		} catch (Exception e) {
 			e.printStackTrace();
 		} finally {
-			is.close();
+			if(is != null) {
+				is.close();
+			}
 		}
 	}
 }


### PR DESCRIPTION
Prevent NullPointerExceptions when trying to close a resource in case of an exception.
