### PR TITLE
MyDashboard page bugfix for project links

### DIFF
--- a/src/main/java/com/gitblit/wicket/freemarker/templates/FilterableProjectList.fm
+++ b/src/main/java/com/gitblit/wicket/freemarker/templates/FilterableProjectList.fm
@@ -6,7 +6,7 @@
 	</div>
 		
 	<div ng-repeat="item in ${ngList} | filter:query" style="padding: 3px;border-top: 1px solid #ddd;">
-		<a href="project/{{item.p}}" title="{{item.i}}"><b>{{item.n}}</b></a>
+		<a href="project/?p={{item.p}}" title="{{item.i}}"><b>{{item.n}}</b></a>
 		<span class="link hidden-tablet hidden-phone" style="color: #bbb;" title="{{item.d}}">{{item.t}}</span>
 		<span class="pull-right">
 			<span style="padding: 0px 5px;color: #888;font-weight:bold;vertical-align:middle;" wicket:message="title:gb.repositories">{{item.c | number}}</span>


### PR DESCRIPTION
## Problem:

In version 1.3.1, on the MyDashboard page, in the "projects" tab, the project name html links listed in the section are formatted wrong; they are missing the ?p= parameter. Clicking on those links redirects back to the home page (MyDashboard).
## What did I expect:

To be taken to the repositories page for the project I clicked.
## What code needs to change:

FilterableProjectList.fm at line 9, needs to add the ?p= url parameter.
I'm basing this on how the WicketUtils.getProjectName(PageParameters params) method works at line 457 and logic in ProjectPage.java at lines 95-98.

Although explicitly changing the url to include the query param 'p' is a simple fix, based on what I read about in GitblitParamUrlCodingStrategy and its parent class MixedParamUrlCodingStrategy, it would seem that the url path "/project/foo" should end up adding a request parameter "p=foo" as setup in GitBligWebApp line 141: mount("/project", ProjectPage.class, "p"); However, I'm not sure exactly why it doesn't seem to be happening.
