### PR TITLE
Add setting to cap number of activity days to display

### DIFF
--- a/releases.moxie
+++ b/releases.moxie
@@ -18,11 +18,15 @@ r19: {
     - Added pptx extension for tree page icon lookup
     - Fixed project links on dashboard page when web.mountParameters=false
     changes: ~
-    additions: ~
+    additions:
+    - Add setting for maximum number of days of activity to that may be requested
     dependencyChanges: ~
     contributors:
     - github/guriguri
     - Doug Ayers
+    - Ori Livneh
+    settings:
+    - { name: 'web.activityDurationMaximum', defaultValue: 30 }
 }
 
 #

--- a/src/main/distrib/data/gitblit.properties
+++ b/src/main/distrib/data/gitblit.properties
@@ -882,6 +882,11 @@ web.activityDuration = 7
 # SINCE 1.3.0
 web.activityDurationChoices = 1 3 7 14 21 28
 
+# Maximum number of days of activity that may be displayed on the activity page.
+#
+# SINCE 1.3.2
+web.activityDurationMaximum = 30
+
 # The number of days of commits to cache in memory for the dashboard, activity,
 # and project pages.  A value of 0 will disable all caching and will parse commits
 # in each repository per-request.  If the value > 0 these pages will try to fulfill

--- a/src/main/java/com/gitblit/wicket/pages/BasePage.java
+++ b/src/main/java/com/gitblit/wicket/pages/BasePage.java
@@ -325,6 +325,7 @@ public abstract class BasePage extends SessionPage {
 		String regex = WicketUtils.getRegEx(params);
 		String team = WicketUtils.getTeam(params);
 		int daysBack = params.getInt("db", 0);
+		int maxDaysBack = GitBlit.getInteger(Keys.web.activityDurationMaximum, 30);
 
 		List<ProjectModel> availableModels = getProjectModels();
 		Set<ProjectModel> models = new HashSet<ProjectModel>();
@@ -372,6 +373,9 @@ public abstract class BasePage extends SessionPage {
 
 		// time-filter the list
 		if (daysBack > 0) {
+			if (maxDaysBack > 0 && daysBack > maxDaysBack) {
+				daysBack = maxDaysBack;
+			}
 			Calendar cal = Calendar.getInstance();
 			cal.set(Calendar.HOUR_OF_DAY, 0);
 			cal.set(Calendar.MINUTE, 0);

--- a/src/main/java/com/gitblit/wicket/pages/MyDashboardPage.java
+++ b/src/main/java/com/gitblit/wicket/pages/MyDashboardPage.java
@@ -96,8 +96,12 @@ public class MyDashboardPage extends DashboardPage {
 
 		// parameters
 		int daysBack = params == null ? 0 : WicketUtils.getDaysBack(params);
+		int maxDaysBack = GitBlit.getInteger(Keys.web.activityDurationMaximum, 30);
 		if (daysBack < 1) {
 			daysBack = GitBlit.getInteger(Keys.web.activityDuration, 7);
+		}
+		if (maxDaysBack > 0 && daysBack > maxDaysBack) {
+			daysBack = maxDaysBack;
 		}
 		Calendar c = Calendar.getInstance();
 		c.add(Calendar.DATE, -1*daysBack);

--- a/src/main/java/com/gitblit/wicket/pages/RootPage.java
+++ b/src/main/java/com/gitblit/wicket/pages/RootPage.java
@@ -345,8 +345,12 @@ public abstract class RootPage extends BasePage {
 	protected List<DropDownMenuItem> getTimeFilterItems(PageParameters params) {
 		// days back choices - additive parameters
 		int daysBack = GitBlit.getInteger(Keys.web.activityDuration, 7);
+		int maxDaysBack = GitBlit.getInteger(Keys.web.activityDurationMaximum, 30);
 		if (daysBack < 1) {
 			daysBack = 7;
+		}
+		if (daysBack > maxDaysBack) {
+			daysBack = maxDaysBack;
 		}
 		PageParameters clonedParams;
 		if (params == null) {
@@ -397,6 +401,7 @@ public abstract class RootPage extends BasePage {
 		String regex = WicketUtils.getRegEx(params);
 		String team = WicketUtils.getTeam(params);
 		int daysBack = params.getInt("db", 0);
+		int maxDaysBack = GitBlit.getInteger(Keys.web.activityDurationMaximum, 30);
 
 		List<RepositoryModel> availableModels = getRepositoryModels();
 		Set<RepositoryModel> models = new HashSet<RepositoryModel>();
@@ -487,6 +492,9 @@ public abstract class RootPage extends BasePage {
 
 		// time-filter the list
 		if (daysBack > 0) {
+			if (maxDaysBack > 0 && daysBack > maxDaysBack) {
+				daysBack = maxDaysBack;
+			}
 			Calendar cal = Calendar.getInstance();
 			cal.set(Calendar.HOUR_OF_DAY, 0);
 			cal.set(Calendar.MINUTE, 0);


### PR DESCRIPTION
This patch adds a setting, 'web.activityDurationMaximum', that specifies the
maximum number of days of activity that may be requested. The default value is
30. When the number of days requested exceeds this value, the request is
handled as though the maximum value was requested.
