### PR TITLE
Allows the home root link top-left anchor to be customised.

### DIFF
--- a/src/main/distrib/data/gitblit.properties
+++ b/src/main/distrib/data/gitblit.properties
@@ -581,6 +581,13 @@ web.siteName =
 # BASEFOLDER
 web.headerLogo = ${baseFolder}/logo.png
 
+# You may specify a different link URL for the logo image anchor.
+# If blank the Gitblit main page URL is used.
+#
+# SINCE 1.3.0
+# BASEFOLDER
+web.rootLink =
+
 # You may specify a custom header background CSS color.  If unspecified, the
 # default color will be used.
 #

--- a/src/main/java/com/gitblit/wicket/pages/BasePage.java
+++ b/src/main/java/com/gitblit/wicket/pages/BasePage.java
@@ -212,7 +212,8 @@ public abstract class BasePage extends SessionPage {
 			add(new Label("title", siteName));
 		}
 
-		ExternalLink rootLink = new ExternalLink("rootLink", urlFor(GitBlitWebApp.HOME_PAGE_CLASS, null).toString());
+		String rootLinkUrl = GitBlit.getString(Keys.web.rootLink, urlFor(GitBlitWebApp.HOME_PAGE_CLASS, null).toString());
+		ExternalLink rootLink = new ExternalLink("rootLink", rootLinkUrl);
 		WicketUtils.setHtmlTooltip(rootLink, GitBlit.getString(Keys.web.siteName, Constants.NAME));
 		add(rootLink);
 


### PR DESCRIPTION
A new property web.rootLink has been introduced to
customise the link underlying the top-left logo in GitBlit.
When undefined the older behaviour is to link to the
GitBlit home page.
