### PR TITLE
Bump Lucene vesion to 4.4.0

### DIFF
--- a/build.moxie
+++ b/build.moxie
@@ -100,7 +100,7 @@ repositories: central, eclipse-snapshots, eclipse
 properties: {
   jetty.version  : 7.6.13.v20130916
   wicket.version : 1.4.21
-  lucene.version : 3.6.1
+  lucene.version : 4.6.0
   jgit.version   : 3.1.0.201310021548-r
   groovy.version : 1.8.8
   bouncycastle.version : 1.47
@@ -133,9 +133,11 @@ dependencies:
 - compile 'org.apache.wicket:wicket-auth-roles:${wicket.version}' :war !org.mockito
 - compile 'org.apache.wicket:wicket-extensions:${wicket.version}' :war !org.mockito
 - compile 'org.wicketstuff:googlecharts:${wicket.version}' :war
+- compile 'org.apache.lucene:lucene-analyzers-common:${lucene.version}' :war :fedclient
 - compile 'org.apache.lucene:lucene-core:${lucene.version}' :war :fedclient
 - compile 'org.apache.lucene:lucene-highlighter:${lucene.version}' :war :fedclient
 - compile 'org.apache.lucene:lucene-memory:${lucene.version}' :war :fedclient
+- compile 'org.apache.lucene:lucene-queryparser:${lucene.version}' :war :fedclient
 - compile 'org.pegdown:pegdown:1.4.1' :war
 - compile 'org.fusesource.wikitext:wikitext-core:${wikitext.version}' :war
 - compile 'org.fusesource.wikitext:twiki-core:${wikitext.version}' :war

--- a/src/main/java/com/gitblit/LuceneExecutor.java
+++ b/src/main/java/com/gitblit/LuceneExecutor.java
@@ -50,7 +50,7 @@ import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.IndexWriterConfig.OpenMode;
 import org.apache.lucene.index.MultiReader;
 import org.apache.lucene.index.Term;
-import org.apache.lucene.queryParser.QueryParser;
+import org.apache.lucene.queryparser.classic.QueryParser;
 import org.apache.lucene.search.BooleanClause.Occur;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.IndexSearcher;


### PR DESCRIPTION
Gerrit Code Review shipps Lucene 4.4.0. For the gerrit-gitblit plugin it is unfortunate to include additionally outdated Lucene version. 
