### PR TITLE
Fixed test.

### DIFF
--- a/src/test/java/com/gitblit/tests/JGitUtilsTest.java
+++ b/src/test/java/com/gitblit/tests/JGitUtilsTest.java
@@ -518,7 +518,7 @@ public class JGitUtilsTest extends GitblitUnitTest {
 		// grab the commits since 2008-07-15
 		commits = JGitUtils.getRevLog(repository, null,
 				new SimpleDateFormat("yyyy-MM-dd").parse("2008-07-15"));
-		assertEquals(12, commits.size());
+		assertEquals(19, commits.size());
 		repository.close();
 	}
 


### PR DESCRIPTION
testRevlog was expecting 12 commits but getting 19. Looking at the
hello-world repository on github (on which the test executes) the 19
commit count appears to be correct.
