### PR TITLE
Evaluate X_Forwarded_Context only when X-Forwarded-Context is not set

### DIFF
--- a/src/main/java/com/gitblit/utils/HttpUtils.java
+++ b/src/main/java/com/gitblit/utils/HttpUtils.java
@@ -80,7 +80,7 @@ public class HttpUtils {
 
         String context = request.getContextPath();
         String forwardedContext = request.getHeader("X-Forwarded-Context");
-        if (forwardedContext != null) {
+        if (StringUtils.isEmpty(forwardedContext)) {
         	forwardedContext = request.getHeader("X_Forwarded_Context");
         }
         if (!StringUtils.isEmpty(forwardedContext)) {


### PR DESCRIPTION
Currently it's not possible to consider the X-Forwarded-Context Header, since it's overwritten by the X_Forwarded_Context Header.
