### PR TITLE
Adding new property web.defaultOrigin.

### DIFF
--- a/src/main/distrib/data/gitblit.properties
+++ b/src/main/distrib/data/gitblit.properties
@@ -921,6 +921,11 @@ web.otherUrls =
 # SINCE 1.3.0
 web.allowAppCloneLinks = true
 
+# Use as the origin name on the Empty Repository page. Default is gitblit.
+#
+# SINCE ???
+web.defaultOrigin = gitblit
+
 # Choose how to present the repositories list.
 #   grouped = group nested/subfolder repositories together (no sorting)
 #   flat = flat list of repositories (sorting allowed)

--- a/src/main/java/com/gitblit/Constants.java
+++ b/src/main/java/com/gitblit/Constants.java
@@ -85,6 +85,8 @@ public class Constants {
 	public static final int LEN_SHORTLOG_REFS = 60;
 
 	public static final String DEFAULT_BRANCH = "default";
+	
+	public static final String DEFAULT_ORIGIN = "gitblit";
 
 	public static final String CONFIG_GITBLIT = "gitblit";
 

--- a/src/main/java/com/gitblit/wicket/pages/EmptyRepositoryPage.java
+++ b/src/main/java/com/gitblit/wicket/pages/EmptyRepositoryPage.java
@@ -24,6 +24,8 @@ import org.apache.wicket.PageParameters;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.protocol.http.WebRequest;
 
+import com.gitblit.Constants;
+import com.gitblit.Keys;
 import com.gitblit.models.RepositoryModel;
 import com.gitblit.models.RepositoryUrl;
 import com.gitblit.models.UserModel;
@@ -61,11 +63,12 @@ public class EmptyRepositoryPage extends RootPage {
 		List<RepositoryUrl> repositoryUrls = app().gitblit().getRepositoryUrls(req, user, repository);
 		RepositoryUrl primaryUrl = repositoryUrls.size() == 0 ? null : repositoryUrls.get(0);
 		String url = primaryUrl != null ? primaryUrl.url : "";
+		String originName = app().settings().getString(Keys.web.defaultOrigin, Constants.DEFAULT_ORIGIN);
 
 		add(new Label("repository", repositoryName));
 		add(new RepositoryUrlPanel("pushurl", false, user, repository));
 		add(new Label("cloneSyntax", MessageFormat.format("git clone {0}", url)));
-		add(new Label("remoteSyntax", MessageFormat.format("git remote add gitblit {0}\ngit push gitblit master", url)));
+		add(new Label("remoteSyntax", MessageFormat.format("git remote add {1} {0}\ngit push {1} master", url, originName)));
 	}
 
 	@Override


### PR DESCRIPTION
The web.defaultOrigin property allows you to specify what origin name is used within the "Empty Repository" page that is displayed after creation of a repository.

Reason for PR: some people within my organization had difficulty understanding the use of "gitblit" instead of "origin" and using the standard "origin" was better for our purposes of explaining Git to users.

NOTE - I didn't know what to fill in as the SINCE value, so I left that as ??? Other than that it was tested locally and found to be working.
