### PR TITLE
LDAP: Authenticated Searches without a manager password

### DIFF
--- a/src/main/distrib/data/gitblit.properties
+++ b/src/main/distrib/data/gitblit.properties
@@ -1516,6 +1516,15 @@ realm.ldap.username = cn=Directory Manager
 # SINCE 1.0.0
 realm.ldap.password = password
 
+# Bind pattern for Authentication.
+#
+# Allow to authenticate an user without LDAP Searches.
+# 
+# e.g. CN=${username},OU=Users,OU=UserControl,OU=MyOrganization,DC=MyDomain
+#
+realm.ldap.bindpattern = 
+
+
 # Delegate team membership control to LDAP.
 #
 # If true, team user memberships will be specified by LDAP groups.  This will


### PR DESCRIPTION
Allow to use the LDAP AuthProvider with a LDAP Server
prohibiting anonymous searches but without providing
a manager password : searches are made on behalf of
the authenticated user.
