### PR TITLE
Redirect all command line arguments for pt.cmd

### DIFF
--- a/src/main/java/pt.cmd
+++ b/src/main/java/pt.cmd
@@ -1,1 +1,1 @@
-@python %~dp0pt.py %1 %2 %3 %4 %5 %6 %7 %8 %9
+@python %~dp0pt.py %*


### PR DESCRIPTION
Redirects all arguments (beginning with %1) for pt.cmd to pt.py. Even if pt.py currently uses less than 9 args, this is imho an unnecessary limitation.
