### PR TITLE
Added option to disable deleting of non empty repositories through the u...

### DIFF
--- a/src/main/distrib/data/gitblit.properties
+++ b/src/main/distrib/data/gitblit.properties
@@ -766,6 +766,11 @@ web.authenticateAdminPages = true
 # SINCE 0.5.0
 web.allowCookieAuthentication = true
 
+# Allow deleting of non empty repositories through the user interface.
+#
+# SINCE 1.6.0
+web.allowDeletingNonEmptyRepositories = true
+
 # Config file for storing project metadata
 #
 # SINCE 1.2.0

--- a/src/main/java/com/gitblit/wicket/panels/RepositoriesPanel.java
+++ b/src/main/java/com/gitblit/wicket/panels/RepositoriesPanel.java
@@ -334,20 +334,36 @@ public class RepositoriesPanel extends BasePanel {
 
 						@Override
 						public void onClick() {
-							if (app().repositories().deleteRepositoryModel(entry)) {
+							// refresh the model
+							RepositoryModel model = app().repositories().getRepositoryModel(entry.name);
+							if (isDeleteAllowed(model) &&
+									app().repositories().deleteRepositoryModel(model)) {
 								if (dp instanceof SortableRepositoriesProvider) {
-									info(MessageFormat.format(getString("gb.repositoryDeleted"), entry));
-									((SortableRepositoriesProvider) dp).remove(entry);
+									info(MessageFormat.format(getString("gb.repositoryDeleted"), model));
+									((SortableRepositoriesProvider) dp).remove(model);
 								} else {
 									setResponsePage(getPage().getClass(), getPage().getPageParameters());
 								}
 							} else {
-								error(MessageFormat.format(getString("gb.repositoryDeleteFailed"), entry));
+								error(MessageFormat.format(getString("gb.repositoryDeleteFailed"), model));
 							}
 						}
+
+						@Override
+						public boolean isEnabled() {
+							return isDeleteAllowed(entry);
+						}
+
+						private boolean isDeleteAllowed(
+								final RepositoryModel model) {
+							return app().settings().getBoolean(Keys.web.allowDeletingNonEmptyRepositories, true)
+									|| !model.hasCommits;
+						}
 					};
-					deleteLink.add(new JavascriptEventConfirmation("onclick", MessageFormat.format(
-							getString("gb.deleteRepository"), entry)));
+					if (deleteLink.isEnabled()) {
+						deleteLink.add(new JavascriptEventConfirmation("onclick", MessageFormat.format(
+								getString("gb.deleteRepository"), entry)));
+					}
 					repositoryLinks.add(deleteLink);
 					row.add(repositoryLinks);
 				} else if (showOwner) {


### PR DESCRIPTION
Hello, i dont really like the idea of using federation to protect repositories against unintentional deletion as suggested in: https://groups.google.com/forum/#!topic/gitblit/qfsxQSUD79c.
This commit adds a new option which disables the delete link if the repository is not empty. If the administrator wishes to delete such a repository, he needs to delete it from the filesystem.

Best regards,
Peter Mihalik
