### PR TITLE
Add option to explicitly specify the use of STARTTLS

### DIFF
--- a/src/main/distrib/data/gitblit.properties
+++ b/src/main/distrib/data/gitblit.properties
@@ -1410,6 +1410,11 @@ mail.debug = false
 # use SMTPs flag
 mail.smtps = false
 
+# use STARTTLS flag
+#
+# SINCE 1.6.0
+mail.starttls = false
+
 # if your smtp server requires authentication, supply the credentials here
 #
 # SINCE 0.6.0

--- a/src/main/java/com/gitblit/service/MailService.java
+++ b/src/main/java/com/gitblit/service/MailService.java
@@ -68,6 +68,7 @@ public class MailService implements Runnable {
 		final String mailUser = settings.getString(Keys.mail.username, null);
 		final String mailPassword = settings.getString(Keys.mail.password, null);
 		final boolean smtps = settings.getBoolean(Keys.mail.smtps, false);
+		final boolean starttls = settings.getBoolean(Keys.mail.starttls, false);
 		boolean authenticate = !StringUtils.isEmpty(mailUser) && !StringUtils.isEmpty(mailPassword);
 		String server = settings.getString(Keys.mail.server, "");
 		if (StringUtils.isEmpty(server)) {
@@ -86,6 +87,7 @@ public class MailService implements Runnable {
 		props.setProperty("mail.smtp.port", String.valueOf(port));
 		props.setProperty("mail.smtp.auth", String.valueOf(authenticate));
 		props.setProperty("mail.smtp.auths", String.valueOf(authenticate));
+		props.setProperty("mail.smtp.starttls.enable", String.valueOf(starttls));
 
 		if (isGMail || smtps) {
 			props.setProperty("mail.smtp.starttls.enable", "true");


### PR DESCRIPTION
Required for servers that use STARTTLS without SMTPS such as Office 365

Please note that I didn't touch the if (isGMail || smtps) part where you also enable STARTTLS. I'm unsure if STARTTLS is mandatory for those, so I guess the safer choice is not to change them.
