### PR TITLE
Fix cache key issue

### DIFF
--- a/src/main/java/com/gitblit/manager/RepositoryManager.java
+++ b/src/main/java/com/gitblit/manager/RepositoryManager.java
@@ -683,7 +683,7 @@ public class RepositoryManager implements IRepositoryManager {
 		repositoryName = repositoryName.replace("%7E", "~").replace("%7e", "~");
 
 		if (!repositoryListCache.containsKey(repositoryName)) {
-			RepositoryModel model = loadRepositoryModel(repositoryName);
+			RepositoryModel model = loadRepositoryModel(repositoryName.toLowerCase());
 			if (model == null) {
 				return null;
 			}


### PR DESCRIPTION
The cache was not finding any repos with upper case letters in repo name. This fix reduces repo page load time on our installation from > 3 sec to 1.5 sec.
