### PR TITLE
localclone.groovy: update getRepositoriesFolder() location

### DIFF
--- a/src/main/distrib/data/groovy/localclone.groovy
+++ b/src/main/distrib/data/groovy/localclone.groovy
@@ -81,7 +81,7 @@ def includeSubmodules = true
 
 def repoName = repository.name
 def destinationFolder = new File(rootFolder, StringUtils.stripDotGit(repoName))
-def srcUrl = 'file://' + new File(GitBlit.getRepositoriesFolder(), repoName).absolutePath
+def srcUrl = 'file://' + new File(gitblit.repositoryManager.getRepositoriesFolder(), repoName).absolutePath
 
 // delete any previous clone
 if (destinationFolder.exists()) {


### PR DESCRIPTION
The getRepositoriesFolder() method was moved in 95cdba46c79d952f2c2baba937e70796674ed57e (20131121) which made this localclone.groovy script throw an unhandled exception.
