### PR TITLE
Update Jetty version to 9.2.1.v20140609

### DIFF
--- a/build.moxie
+++ b/build.moxie
@@ -101,7 +101,7 @@ repositories: central, eclipse-snapshots, eclipse
 
 # Convenience properties for dependencies
 properties: {
-  jetty.version  : 9.1.4.v20140401
+  jetty.version  : 9.2.1.v20140609
   wicket.version : 1.4.21
   lucene.version : 4.6.0
   jgit.version   : 3.3.1.201403241930-r


### PR DESCRIPTION
The Jetty 9.2 quick start mechanism provides almost an order of
magnitude improvement in start time [1].

[1] https://webtide.com/jetty-9-quick-start/
