### PR TITLE
Add setting to make the Git repo URL configurable

### DIFF
--- a/src/main/distrib/data/gitblit.properties
+++ b/src/main/distrib/data/gitblit.properties
@@ -850,6 +850,12 @@ web.siteName =
 # SINCE 1.4.0
 web.canonicalUrl = 
 
+# The URL of the GitServlet used for the clone URLs.
+# e.g. web.gitServletUrl = /r/
+#
+# SINCE 1.6.1
+web.gitServletUrl = 
+
 # You may specify a different logo image for the header but it must be 120x45px.
 # If the specified file does not exist, the default Gitblit logo will be used.
 #

--- a/src/main/java/com/gitblit/manager/GitblitManager.java
+++ b/src/main/java/com/gitblit/manager/GitblitManager.java
@@ -395,9 +395,13 @@ public class GitblitManager implements IGitblit {
 		if (StringUtils.isEmpty(gitblitUrl)) {
 			gitblitUrl = HttpUtils.getGitblitURL(request);
 		}
+		String gitServletUrl = settings.getString(Keys.web.gitServletUrl, Constants.R_PATH);
+		if (StringUtils.isEmpty(gitServletUrl)) {
+		    gitServletUrl = Constants.R_PATH;
+		}
 		StringBuilder sb = new StringBuilder();
 		sb.append(gitblitUrl);
-		sb.append(Constants.R_PATH);
+		sb.append(gitServletUrl);
 		sb.append(repository.name);
 
 		// inject username into repository url if authentication is required


### PR DESCRIPTION
When Gerrit and Gitblit are deployed on the same server /r/ might be used by Gerrit. Add a config setting to change the shown URL to another primary URL