### PR TITLE
Fix NPE when there are two repositories which only differ in case

### DIFF
--- a/src/main/java/com/gitblit/manager/RepositoryManager.java
+++ b/src/main/java/com/gitblit/manager/RepositoryManager.java
@@ -702,7 +702,7 @@ public class RepositoryManager implements IRepositoryManager {
 		// cached model
 		RepositoryModel model = repositoryListCache.get(repositoryKey);
 
-		if (gcExecutor.isCollectingGarbage(model.name)) {
+		if (isCollectingGarbage(model.name)) {
 			// Gitblit is busy collecting garbage, use our cached model
 			RepositoryModel rm = DeepCopier.copy(model);
 			rm.isCollectingGarbage = true;
@@ -1287,7 +1287,7 @@ public class RepositoryManager implements IRepositoryManager {
 	@Override
 	public void updateRepositoryModel(String repositoryName, RepositoryModel repository,
 			boolean isCreate) throws GitBlitException {
-		if (gcExecutor.isCollectingGarbage(repositoryName)) {
+		if (isCollectingGarbage(repositoryName)) {
 			throw new GitBlitException(MessageFormat.format("sorry, Gitblit is busy collecting garbage in {0}",
 					repositoryName));
 		}


### PR DESCRIPTION
We had two repositories which differed only in case. This caused an NPE during start. Using the guarded method restores the old behavior (like in Gitblit 1.3.2) where only one of the two repos is shown in the overview.

At least better than failing to start ;)
