### PR TITLE
Extract user name from client certificate with regex pattern.

### DIFF
--- a/src/main/distrib/data/gitblit.properties
+++ b/src/main/distrib/data/gitblit.properties
@@ -529,6 +529,17 @@ git.maxObjectSizeLimit = 0
 # SINCE 1.5.0
 git.maxPackSizeLimit = -1
 
+# Regex pattern for extracting some part of the common name (CN) of the
+# certificate subject.
+#
+# default: *. for getting the whole string.
+git.certificateUserRegexPattern = [\\D][0-9]{6}
+
+# For converting the extracted common name (CN) to uppercase letters.
+#
+# default: false
+git.certificateUserToUppercase = true
+
 # Use the Gitblit patch receive pack for processing contributions and tickets.
 # This allows the user to push a patch using the familiar Gerrit syntax:
 #

--- a/src/main/distrib/data/gitblit.properties
+++ b/src/main/distrib/data/gitblit.properties
@@ -533,12 +533,12 @@ git.maxPackSizeLimit = -1
 # certificate subject.
 #
 # default: *. for getting the whole string.
-git.certificateUserRegexPattern = [\\D][0-9]{6}
+git.certificateUserRegexPattern = .*
 
 # For converting the extracted common name (CN) to uppercase letters.
 #
 # default: false
-git.certificateUserToUppercase = true
+git.certificateUserToUppercase = false
 
 # Use the Gitblit patch receive pack for processing contributions and tickets.
 # This allows the user to push a patch using the familiar Gerrit syntax:

--- a/src/main/java/com/gitblit/manager/AuthenticationManager.java
+++ b/src/main/java/com/gitblit/manager/AuthenticationManager.java
@@ -227,7 +227,9 @@ public class AuthenticationManager implements IAuthenticationManager {
 		// try to authenticate by certificate
 		boolean checkValidity = settings.getBoolean(Keys.git.enforceCertificateValidity, true);
 		String [] oids = settings.getStrings(Keys.git.certificateUsernameOIDs).toArray(new String[0]);
-		UserModel model = HttpUtils.getUserModelFromCertificate(httpRequest, checkValidity, oids);
+    String regexPattern = settings.getString(Keys.server.regexClientCert, ".*");
+    boolean isToUppercase = Boolean.getBoolean(settings.getString(Keys.server.clientCertUserToUppercase, "false"));
+		UserModel model = HttpUtils.getUserModelFromCertificate(httpRequest, checkValidity, regexPattern, isToUppercase, oids);
 		if (model != null) {
 			// grab real user model and preserve certificate serial number
 			UserModel user = userManager.getUserModel(model.username);

--- a/src/main/java/com/gitblit/manager/AuthenticationManager.java
+++ b/src/main/java/com/gitblit/manager/AuthenticationManager.java
@@ -227,9 +227,9 @@ public class AuthenticationManager implements IAuthenticationManager {
 		// try to authenticate by certificate
 		boolean checkValidity = settings.getBoolean(Keys.git.enforceCertificateValidity, true);
 		String [] oids = settings.getStrings(Keys.git.certificateUsernameOIDs).toArray(new String[0]);
-    String regexPattern = settings.getString(Keys.server.regexClientCert, ".*");
-    boolean isToUppercase = Boolean.getBoolean(settings.getString(Keys.server.clientCertUserToUppercase, "false"));
-		UserModel model = HttpUtils.getUserModelFromCertificate(httpRequest, checkValidity, regexPattern, isToUppercase, oids);
+    String regexPattern = settings.getString(Keys.git.certificateUserRegexPattern, ".*");
+    boolean isToUppercase = Boolean.getBoolean(settings.getString(Keys.git.certificateUserToUppercase, "false"));
+    UserModel model = HttpUtils.getUserModelFromCertificate(httpRequest, checkValidity, regexPattern, isToUppercase, oids);
 		if (model != null) {
 			// grab real user model and preserve certificate serial number
 			UserModel user = userManager.getUserModel(model.username);

--- a/src/test/java/com/gitblit/tests/X509UtilsTest.java
+++ b/src/test/java/com/gitblit/tests/X509UtilsTest.java
@@ -91,14 +91,14 @@ public class X509UtilsTest extends GitblitUnitTest {
 		userMetadata.oids.put("C",  "US");
 
 		X509Certificate cert1 = X509Utils.newClientCertificate(userMetadata, caPrivateKey, caCert, storeFile.getParentFile());
-		UserModel userModel1 = HttpUtils.getUserModelFromCertificate(cert1);
+		UserModel userModel1 = HttpUtils.getUserModelFromCertificate(cert1, ".*", false);
 		assertEquals(userMetadata.commonName, userModel1.username);
 		assertEquals(userMetadata.emailAddress, userModel1.emailAddress);
 		assertEquals("C=US,O=Gitblit,OU=Gitblit,CN=james", cert1.getSubjectDN().getName());
 
 
 		X509Certificate cert2 = X509Utils.newClientCertificate(userMetadata, caPrivateKey, caCert, storeFile.getParentFile());
-		UserModel userModel2 = HttpUtils.getUserModelFromCertificate(cert2);
+		UserModel userModel2 = HttpUtils.getUserModelFromCertificate(cert1, ".*", false);
 		assertEquals(userMetadata.commonName, userModel2.username);
 		assertEquals(userMetadata.emailAddress, userModel2.emailAddress);
 		assertEquals("C=US,O=Gitblit,OU=Gitblit,CN=james", cert2.getSubjectDN().getName());


### PR DESCRIPTION
Introduce a property "server.regexClientCert" and "server.clientCertUserToUppercase" to have the opportunity to extract the username with a self defined regex pattern and use the username to perform a login.