### PR TITLE
Repository url is now r

### DIFF
--- a/src/main/distrib/data/groovy/jenkins.groovy
+++ b/src/main/distrib/data/groovy/jenkins.groovy
@@ -70,7 +70,7 @@ logger.info("jenkins hook triggered by ${user.username} for ${repository.name}")
 def jenkinsUrl = gitblit.getString('groovy.jenkinsServer', 'http://yourserver/jenkins')
 
 // define the trigger url
-def triggerUrl = jenkinsUrl + "/git/notifyCommit?url=$url/git/$repository.name"
+def triggerUrl = jenkinsUrl + "/git/notifyCommit?url=${url}/r/${repository.name}"
 
 // trigger the build
 new URL(triggerUrl).getContent()


### PR DESCRIPTION
The previous 'triggerUrl' version causes a response similar to 'No git jobs using repository: http://gitblit-host/gitblit/git/repo.git'. The wroking url is 'http://gitblit-host/gitblit/r/repo.git'.
I also added brackets to improve readability
