### PR TITLE
Bug in RawServlet.java

### DIFF
--- a/src/main/java/com/gitblit/servlet/RawServlet.java
+++ b/src/main/java/com/gitblit/servlet/RawServlet.java
@@ -172,7 +172,7 @@ public class RawServlet extends DaggerServlet {
 			} else {
 				repository = path.substring(0, slash);
 			}
-			offset += ( slash + 1 );
+			offset = ( slash + 1 );
 			r = repositoryManager.getRepository(repository, false);
 			if (repository.equals(path)) {
 				// either only repository in url or no repository found


### PR DESCRIPTION
Bug in the RawServlet in extracting the repository out of the path. The offset for finding the next slash should be the index of the current slash + 1, not the last offset + the index of the current slash.
