### PR TITLE
Added a new property web.displayUserPanel

### DIFF
--- a/releases.moxie
+++ b/releases.moxie
@@ -12,6 +12,8 @@ r27: {
     fixes: ~
     changes: ~
     additions: ~
+    settings:
+    - { name: web.displayUserPanel, defaultValue: 'true' }
     dependencyChanges: ~
     contributors: ~
 }

--- a/src/main/distrib/data/gitblit.properties
+++ b/src/main/distrib/data/gitblit.properties
@@ -767,6 +767,12 @@ realm.userService = ${baseFolder}/users.conf
 #    salesforce
 #    windows
 
+# Allows to hide the user logon form or dropdown menu from the top pane 
+# if it's not needed.
+#
+# SINCE 1.6.3
+web.displayUserPanel = true
+
 # e.g. realm.authenticationProviders = htpasswd windows
 #
 # SINCE 1.4.0

--- a/src/main/java/com/gitblit/wicket/pages/RootPage.java
+++ b/src/main/java/com/gitblit/wicket/pages/RootPage.java
@@ -151,6 +151,7 @@ public abstract class RootPage extends BasePage {
 		boolean authenticateAdmin = app().settings().getBoolean(Keys.web.authenticateAdminPages, true);
 		boolean allowAdmin = app().settings().getBoolean(Keys.web.allowAdministration, true);
 		boolean allowLucene = app().settings().getBoolean(Keys.web.allowLuceneIndexing, true);
+		boolean displayUserPanel = app().settings().getBoolean(Keys.web.displayUserPanel, true);
 		boolean isLoggedIn = GitBlitWebSession.get().isLoggedIn();
 
 		if (authenticateAdmin) {
@@ -168,7 +169,7 @@ public abstract class RootPage extends BasePage {
 			}
 		}
 
-		if (authenticateView || authenticateAdmin) {
+		if (displayUserPanel && (authenticateView || authenticateAdmin)) {
 			if (isLoggedIn) {
 				UserMenu userFragment = new UserMenu("userPanel", "userMenuFragment", RootPage.this);
 				add(userFragment);


### PR DESCRIPTION
This property allows the administrator to hide the user related part of the top panel. This can come handy if
there's no use for it (i.e. if Gitblit runs as Gerrit plugin, which is exactly why I'd like to hide it -- there's no use for it then and the options availible don't work anyway).
