### PR TITLE
Added a new property: web.displayUserPanel

### DIFF
--- a/releases.moxie
+++ b/releases.moxie
@@ -36,6 +36,8 @@ r27: {
     - Freemarker 2.3.20 (ticket-124)
     - Lucene 4.10.0 (ticket-159)
     - SSHD 0.13.0 (ticket-218)
+    settings:
+    - { name: web.displayUserPanel, defaultValue: 'true' }
     contributors:
     - James Moger
     - David Ostrovsky

--- a/src/main/distrib/data/defaults.properties
+++ b/src/main/distrib/data/defaults.properties
@@ -1344,6 +1344,12 @@ web.aggressiveHeapManagement = false
 # RESTART REQUIRED
 web.debugMode = false
 
+# Allows to hide the user logon form or dropdown menu from the top pane 
+# if it's not needed.
+#
+# SINCE 1.7.0
+web.displayUserPanel = true
+
 # Force a default locale for all users, ignoring the browser's settings.
 # An empty value allows Gitblit to use the translation preferred by the browser.
 #

--- a/src/main/java/com/gitblit/wicket/pages/RootPage.java
+++ b/src/main/java/com/gitblit/wicket/pages/RootPage.java
@@ -151,6 +151,7 @@ public abstract class RootPage extends BasePage {
 		boolean authenticateAdmin = app().settings().getBoolean(Keys.web.authenticateAdminPages, true);
 		boolean allowAdmin = app().settings().getBoolean(Keys.web.allowAdministration, true);
 		boolean allowLucene = app().settings().getBoolean(Keys.web.allowLuceneIndexing, true);
+		boolean displayUserPanel = app().settings().getBoolean(Keys.web.displayUserPanel, true);
 		boolean isLoggedIn = GitBlitWebSession.get().isLoggedIn();
 
 		if (authenticateAdmin) {
@@ -168,7 +169,7 @@ public abstract class RootPage extends BasePage {
 			}
 		}
 
-		if (authenticateView || authenticateAdmin) {
+		if (displayUserPanel && (authenticateView || authenticateAdmin)) {
 			if (isLoggedIn) {
 				UserMenu userFragment = new UserMenu("userPanel", "userMenuFragment", RootPage.this);
 				add(userFragment);


### PR DESCRIPTION
This property allows the administrator to hide the user related part of the top panel. This can come handy if there's no use for it (i.e. if Gitblit runs as Gerrit plugin).
