### PR TITLE
Add support for configurable HTTP proxy host/port in PluginManager.java

### DIFF
--- a/src/main/distrib/data/defaults.properties
+++ b/src/main/distrib/data/defaults.properties
@@ -572,6 +572,16 @@ plugins.folder = ${baseFolder}/plugins
 # SINCE 1.5.0
 plugins.registry = http://plugins.gitblit.com/plugins.json
 
+# The HTTP proxy host for plugin manager.
+#
+# SINCE 1.7.0
+plugins.httpProxyHost = 
+
+# The HTTP proxy port for plugin manager.
+#
+# SINCE 1.7.0
+plugins.httpProxyPort = 
+
 # Number of threads used to handle miscellaneous tasks in the background.
 #
 # SINCE 1.6.0

--- a/src/main/java/com/gitblit/manager/PluginManager.java
+++ b/src/main/java/com/gitblit/manager/PluginManager.java
@@ -22,6 +22,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
+import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.net.URL;
 import java.net.URLConnection;
@@ -586,7 +587,14 @@ public class PluginManager implements IPluginManager, PluginStateListener {
 	}
 
 	protected Proxy getProxy(URL url) {
-		return java.net.Proxy.NO_PROXY;
+		String proxyHost = runtimeManager.getSettings().getString(Keys.plugins.httpProxyHost, "");
+		String proxyPort = runtimeManager.getSettings().getString(Keys.plugins.httpProxyPort, "");
+		
+		if (!StringUtils.isEmpty(proxyHost)  && !StringUtils.isEmpty(proxyPort)) {
+			return new Proxy(Proxy.Type.HTTP, new InetSocketAddress(proxyHost, Integer.parseInt(proxyPort)));
+		} else {
+			return java.net.Proxy.NO_PROXY;
+		}
 	}
 
 	protected String getProxyAuthorization(URL url) {


### PR DESCRIPTION
I would like to propose a small improvement to Gitblit by adding a proxy host/port setting for PluginManager.

Formerly by default the PluginMaganer would support no proxy setting. For servers behind firewall and HTTP proxy this would prevent installation of gitblit plugins.
