### PR TITLE
issue 564: enable ticket page update on tomcat with redirects

### DIFF
--- a/src/main/java/com/gitblit/wicket/pages/TicketPage.java
+++ b/src/main/java/com/gitblit/wicket/pages/TicketPage.java
@@ -378,7 +378,7 @@ public class TicketPage extends RepositoryPage {
 								}
 								TicketModel update = app().tickets().updateTicket(repository, ticket.number, change);
 								app().tickets().createNotifier().sendMailing(update);
-								setResponsePage(TicketsPage.class, getPageParameters());
+								redirectTo(TicketsPage.class, getPageParameters());
 							}
 						};
 						String css = TicketsUI.getStatusClass(item.getModel().getObject());
@@ -442,7 +442,7 @@ public class TicketPage extends RepositoryPage {
 								}
 								TicketModel update = app().tickets().updateTicket(repository, ticket.number, change);
 								app().tickets().createNotifier().sendMailing(update);
-								setResponsePage(TicketsPage.class, getPageParameters());
+								redirectTo(TicketsPage.class, getPageParameters());
 							}
 						};
 						item.add(link);
@@ -487,7 +487,7 @@ public class TicketPage extends RepositoryPage {
 								}
 								TicketModel update = app().tickets().updateTicket(repository, ticket.number, change);
 								app().tickets().createNotifier().sendMailing(update);
-								setResponsePage(TicketsPage.class, getPageParameters());
+								redirectTo(TicketsPage.class, getPageParameters());
 							}
 						};
 						item.add(link);
@@ -560,7 +560,7 @@ public class TicketPage extends RepositoryPage {
 						change.vote(user.username);
 					}
 					app().tickets().updateTicket(repository, ticket.number, change);
-					setResponsePage(TicketsPage.class, getPageParameters());
+					redirectTo(TicketsPage.class, getPageParameters());
 				}
 			};
 			add(link);
@@ -600,7 +600,7 @@ public class TicketPage extends RepositoryPage {
 						change.watch(user.username);
 					}
 					app().tickets().updateTicket(repository, ticket.number, change);
-					setResponsePage(TicketsPage.class, getPageParameters());
+					redirectTo(TicketsPage.class, getPageParameters());
 				}
 			};
 			add(link);
@@ -1297,7 +1297,7 @@ public class TicketPage extends RepositoryPage {
 		}
 		TicketModel updatedTicket = app().tickets().updateTicket(getRepositoryModel(), ticket.number, change);
 		app().tickets().createNotifier().sendMailing(updatedTicket);
-		setResponsePage(TicketsPage.class, getPageParameters());
+		redirectTo(TicketsPage.class, getPageParameters());
 	}
 
 	protected <X extends MarkupContainer> X setNewTarget(X x) {
@@ -1408,8 +1408,8 @@ public class TicketPage extends RepositoryPage {
 								GitBlitWebSession.get().cacheErrorMessage(msg);
 								logger.error(msg);
 							}
-
-							setResponsePage(TicketsPage.class, getPageParameters());
+							
+							redirectTo(TicketsPage.class, getPageParameters());
 						}
 					};
 					mergePanel.add(mergeButton);

--- a/src/main/java/com/gitblit/wicket/panels/CommentPanel.java
+++ b/src/main/java/com/gitblit/wicket/panels/CommentPanel.java
@@ -15,12 +15,15 @@
  */
 package com.gitblit.wicket.panels;
 
+import org.apache.wicket.PageParameters;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.ajax.markup.html.form.AjaxButton;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.form.Form;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
+import org.apache.wicket.protocol.http.RequestUtils;
+import org.apache.wicket.request.target.basic.RedirectRequestTarget;
 
 import com.gitblit.models.RepositoryModel;
 import com.gitblit.models.TicketModel;
@@ -79,7 +82,7 @@ public class CommentPanel extends BasePanel {
 					TicketModel updatedTicket = app().tickets().updateTicket(repository, ticket.number, newComment);
 					if (updatedTicket != null) {
 						app().tickets().createNotifier().sendMailing(updatedTicket);
-						setResponsePage(pageClass, WicketUtils.newObjectParameter(updatedTicket.repository, "" + ticket.number));
+						redirectTo(pageClass, WicketUtils.newObjectParameter(updatedTicket.repository, "" + ticket.number));
 					} else {
 						error("Failed to add comment!");
 					}
@@ -87,6 +90,24 @@ public class CommentPanel extends BasePanel {
 					// TODO update comment
 				}
 			}
+			
+            /**
+             * Steal from BasePage to realize redirection.
+             * 
+             * @see BasePage
+             * @author krulls@GitHub; ECG Leipzig GmbH, Germany, 2015
+             * 
+             * @param pageClass
+             * @param parameters
+             * @return
+             */
+            private void redirectTo(Class<? extends BasePage> pageClass, PageParameters parameters)
+            {
+                String relativeUrl = urlFor(pageClass, parameters).toString();
+                String canonicalUrl = RequestUtils.toAbsolutePath(relativeUrl);
+                getRequestCycle().setRequestTarget(new RedirectRequestTarget(canonicalUrl));
+            }
+			
 		}.setVisible(ticket != null && ticket.number > 0));
 
 		final IModel<String> markdownPreviewModel = Model.of();


### PR DESCRIPTION
Testet behaviour with Tomcat 7.0.59 on Windows 7; also testet GitBlit GO for compatibility.

The changes are related to [issue 455] (https://code.google.com/p/gitblit/issues/detail?id=564) and the corresponding [ticket 136] (https://dev.gitblit.com/tickets/gitblit.git/136) with commit [2598bf3] (https://dev.gitblit.com/commit/gitblit.git/2598bf3ff526f46259244d7c5f60dcc2241f3020;jsessionid=1eyio76oowfmh6gjmlb848k4v).

Manual test steps:
- create repository (non bare)
- create new ticket
- in the ticket page change status, make a comment etc.