### PR TITLE
(ticket-537) user bindUser for group detection

### DIFF
--- a/src/main/java/com/gitblit/auth/LdapAuthProvider.java
+++ b/src/main/java/com/gitblit/auth/LdapAuthProvider.java
@@ -321,7 +321,6 @@ public class LdapAuthProvider extends UsernamePasswordAuthenticationProvider {
 				if (result != null && result.getEntryCount() == 1) {
 					SearchResultEntry loggingInUser = result.getSearchEntries().get(0);
 					String loggingInUserDN = loggingInUser.getDN();
-
 					if (alreadyAuthenticated || isAuthenticated(ldapConnection, loggingInUserDN, new String(password))) {
 						logger.debug("LDAP authenticated: " + username);
 
@@ -438,7 +437,7 @@ public class LdapAuthProvider extends UsernamePasswordAuthenticationProvider {
 
 	private void getTeamsFromLdap(LDAPConnection ldapConnection, String simpleUsername, SearchResultEntry loggingInUser, UserModel user) {
 		String loggingInUserDN = loggingInUser.getDN();
-
+		
 		// Clear the users team memberships - we're going to get them from LDAP
 		user.teams.clear();
 
@@ -535,7 +534,7 @@ public class LdapAuthProvider extends UsernamePasswordAuthenticationProvider {
 	private boolean isAuthenticated(LDAPConnection ldapConnection, String userDn, String password) {
 	  LDAPConnection authldapConnection = getLdapConnection();
 		try {
-		  if (settings.getBoolean(Keys.realm.ldap.username, false)) {
+		  if (!settings.getString(Keys.realm.ldap.username, "").isEmpty()) {
 		    authldapConnection.bind(userDn, password);
 		  } else {
 			  // Binding will stop any LDAP-Injection Attacks since the searched-for user needs to bind to that DN

--- a/src/main/java/com/gitblit/auth/LdapAuthProvider.java
+++ b/src/main/java/com/gitblit/auth/LdapAuthProvider.java
@@ -533,13 +533,20 @@ public class LdapAuthProvider extends UsernamePasswordAuthenticationProvider {
 	}
 
 	private boolean isAuthenticated(LDAPConnection ldapConnection, String userDn, String password) {
+	  LDAPConnection authldapConnection = getLdapConnection();
 		try {
-			// Binding will stop any LDAP-Injection Attacks since the searched-for user needs to bind to that DN
-			ldapConnection.bind(userDn, password);
+		  if (settings.getBoolean(Keys.realm.ldap.username, false)) {
+		    authldapConnection.bind(userDn, password);
+		  } else {
+			  // Binding will stop any LDAP-Injection Attacks since the searched-for user needs to bind to that DN
+		    ldapConnection.bind(userDn, password);
+		  }
 			return true;
 		} catch (LDAPException e) {
 			logger.error("Error authenticating user", e);
 			return false;
+		} finally {
+		  authldapConnection.close();
 		}
 	}
 


### PR DESCRIPTION
This should is a fix for *( https://code.google.com/p/gitblit/issues/detail?id=537) *
-> For security reason a normal user cannot read groups from our LDAP, so in this case the search user has to be used for group/team detection.

would appreciate some feedback : 
 1: Based on the comment "// Binding will stop any LDAP-Injection Attacks ...." should there be a separate setting for enabling this 'feature', or what actually is a LDAP-Injection Attack?
 2: getLdapConnection() should  now be called createLdapConnection() ?


**Edit:** 
*Original google code ticket is not available anymore?*
Problem was:
 - inital ldap bind does work to authenticate the user
 - the new connection was then used to no query the team memberships
   -  his works with an AD, but on OpenLDAP a user has not the right's to see the groups
 - so in (our) OpenLDAP setup the Team memberships have to user the 'old' non user ldap connection
