### PR TITLE
Deny access to /com and /org folders in GO setup

### DIFF
--- a/src/main/java/com/gitblit/guice/WebModule.java
+++ b/src/main/java/com/gitblit/guice/WebModule.java
@@ -19,6 +19,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import com.gitblit.Constants;
+import com.gitblit.servlet.AccessDeniedServlet;
 import com.gitblit.servlet.BranchGraphServlet;
 import com.gitblit.servlet.DownloadZipFilter;
 import com.gitblit.servlet.DownloadZipServlet;
@@ -52,6 +53,11 @@ import com.google.inject.servlet.ServletModule;
 public class WebModule extends ServletModule {
 
 	final static String ALL = "/*";
+	private boolean isGO;
+
+	public WebModule(boolean isGO) {
+		this.isGO=isGO;
+	}
 
 	@Override
 	protected void configureServlets() {
@@ -69,7 +75,20 @@ public class WebModule extends ServletModule {
 		serve(Constants.PT_PATH).with(PtServlet.class);
 		serve("/robots.txt").with(RobotsTxtServlet.class);
 		serve("/logo.png").with(LogoServlet.class);
-
+		if(isGO)
+		{
+			/* Prevent accidental access to 'resources' such as GitBlit java classes
+			 *
+			 * In the GO setup the JAR containing the application and the WAR injected
+			 * into Jetty are the same file. However Jetty expects to serve the entire WAR
+			 * contents, except the WEB-INF folder. Thus, all java binary classes in the
+			 * JAR are served by default as is they were legitimate resources.
+			 *
+			 * The below servlet mappings prevent that behavior
+			 */
+			serve(fuzzy("/com/")).with(AccessDeniedServlet.class);
+			serve(fuzzy("/org/")).with(AccessDeniedServlet.class);
+		}
 		// global filters
 		filter(ALL).through(ProxyFilter.class);
 		filter(ALL).through(EnforceAuthenticationFilter.class);

--- a/src/main/java/com/gitblit/servlet/AccessDeniedServlet.java
+++ b/src/main/java/com/gitblit/servlet/AccessDeniedServlet.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2015 Jean-Baptiste Mayer
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.gitblit.servlet;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import com.google.inject.Singleton;
+
+/**
+ * Access-denied Servlet.
+ * 
+ * This servlet serves only 404 Not Found error replies.
+ * 
+ * This servlet is used to override the container's default behavior to serve
+ * all contents of the application's WAR. We can selectively prevent access to
+ * a specific path simply by mapping this servlet onto specific paths.
+ * 
+ * 
+ * @author Jean-Baptiste Mayer
+ *
+ */
+@Singleton
+public class AccessDeniedServlet extends HttpServlet {
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = -3239463647917811122L;
+
+	@Override
+	protected void doPost(HttpServletRequest request, HttpServletResponse response)
+			throws ServletException, java.io.IOException {
+		processRequest(request, response);
+	}
+
+	@Override
+	protected void doGet(HttpServletRequest request, HttpServletResponse response)
+			throws ServletException, IOException {
+		processRequest(request, response);
+	}
+
+	private void processRequest(HttpServletRequest request,
+			HttpServletResponse response) {
+		response.setStatus(HttpServletResponse.SC_NOT_FOUND);
+	}
+}

--- a/src/main/java/com/gitblit/servlet/GitblitContext.java
+++ b/src/main/java/com/gitblit/servlet/GitblitContext.java
@@ -129,7 +129,7 @@ public class GitblitContext extends GuiceServletContextListener {
 	 * Returns Gitblit's Guice injection modules.
 	 */
 	protected AbstractModule [] getModules() {
-		return new AbstractModule [] { new CoreModule(), new WebModule() };
+		return new AbstractModule [] { new CoreModule(), new WebModule(null!=goBaseFolder) };
 	}
 
 	/**


### PR DESCRIPTION
Further to earlier pull request https://github.com/gitblit/gitblit/pull/251 - this pull request fixes the unexpected disclosure of java classes:
 
Added a servlet to serve "Access Denied"
Added conditional mapping of /com and /org folders in the web setup