### PR TITLE
A bug with Tomcat and SSO

### DIFF
--- a/src/main/distrib/data/defaults.properties
+++ b/src/main/distrib/data/defaults.properties
@@ -768,6 +768,15 @@ web.authenticateAdminPages = true
 # SINCE 0.5.0
 web.allowCookieAuthentication = true
 
+# Allows gitblit to rewrite session
+# It's a security feature that should be kept on true but some external
+# authentication methode don't like that, ie if you delegate it to tomcat.
+# If you try such a setup and see strange comportement, you should try to
+# set it to false
+#
+# SINCE 1.7.0
+web.rewriteSession = true
+
 # Allow deletion of non-empty repositories. This is enforced for all delete vectors.
 #
 # SINCE 1.6.0

--- a/src/main/java/com/gitblit/wicket/pages/SessionPage.java
+++ b/src/main/java/com/gitblit/wicket/pages/SessionPage.java
@@ -96,7 +96,9 @@ public abstract class SessionPage extends WebPage {
 					.getAttribute(Constants.AUTHENTICATION_TYPE);
 
 			// issue 62: fix session fixation vulnerability
-			session.replaceSession();
+			if(app().settings().getBoolean(Keys.web.rewriteSession, true)) {
+				session.replaceSession();				
+			}
 			session.setUser(user);
 
 			request.getSession().setAttribute(Constants.AUTHENTICATION_TYPE, authenticationType);


### PR DESCRIPTION
The way wicket change session is not tomcat friendly and you use it in com.gitblit.wicket.pages.SessionPage. I think it change the session id too late, the reply header have been already sent. It break CAS (the SSO solution we use) as it really on session id to follow user. But changing session should be kept for security reasons. Tomcat can do that on it's own. So I added a option that allows to disable this in case some one might need it.