### PR TITLE
Keepsession

### DIFF
--- a/src/main/java/com/gitblit/wicket/pages/SessionPage.java
+++ b/src/main/java/com/gitblit/wicket/pages/SessionPage.java
@@ -96,7 +96,12 @@ public abstract class SessionPage extends WebPage {
 					.getAttribute(Constants.AUTHENTICATION_TYPE);
 
 			// issue 62: fix session fixation vulnerability
-			session.replaceSession();
+			// but only if authentication was done in the container.
+			// It avoid double change of session, that some authentication method
+			// don't like
+			if (AuthenticationType.CONTAINER != authenticationType) {
+				session.replaceSession();
+			}			
 			session.setUser(user);
 
 			request.getSession().setAttribute(Constants.AUTHENTICATION_TYPE, authenticationType);


### PR DESCRIPTION
The way wicket change session is not tomcat friendly and you use it in com.gitblit.wicket.pages.SessionPage. I think it change the session id too late, the reply header have been already sent. It break CAS (the SSO solution we use) as it really on session id to follow user. But changing session should be kept for security reasons. Tomcat can do that on it's own. So I added a option that allows to disable this in case some one might need it.

This time done without a specific option.