### PR TITLE
Support for different post/host in the ssh://... url in the web interface.

### DIFF
--- a/src/main/distrib/data/gitblit.properties
+++ b/src/main/distrib/data/gitblit.properties
@@ -110,6 +110,22 @@ git.sshPort = 29418
 # RESTART REQUIRED
 git.sshBindInterface = 
 
+# Specifies the ssh postname to publish in the web interface.
+# You may specify a hostname if you're forwarding from a different
+# hostname than web.canonicalUrl points to
+#
+# SINCE 1.6.3
+# RESTART REQUIRED
+git.sshDisplayHost = 
+
+# Specifies the ssh port to publish in the web interface.
+# You may specify a port that has been forwarded to git.sshPort
+# Recommended value: 22
+#
+# SINCE 1.6.3
+# RESTART REQUIRED
+git.sshDisplayPort = 
+
 # Specify the SSH key manager to use for retrieving, storing, and removing
 # SSH keys.
 #

--- a/src/main/java/com/gitblit/servlet/SparkleShareInviteServlet.java
+++ b/src/main/java/com/gitblit/servlet/SparkleShareInviteServlet.java
@@ -83,6 +83,8 @@ public class SparkleShareInviteServlet extends DaggerServlet {
 			response.getWriter().append("SSH is not active on this server!");
 			return;
 		}
+		int sshDisplayPort = settings.getInteger(Keys.git.sshDisplayPort, sshPort);
+
 		// extract repo name from request
 		String repoUrl = request.getPathInfo().substring(1);
 
@@ -106,6 +108,7 @@ public class SparkleShareInviteServlet extends DaggerServlet {
 		if (!StringUtils.isEmpty(url) && url.indexOf("localhost") == -1) {
 			host = new URL(url).getHost();
 		}
+		String sshDisplayHost = settings.getString(Keys.git.sshDisplayHost, host);
 
 		UserModel user;
 		if (StringUtils.isEmpty(username)) {
@@ -135,7 +138,7 @@ public class SparkleShareInviteServlet extends DaggerServlet {
 		StringBuilder sb = new StringBuilder();
 		sb.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
 		sb.append("<sparkleshare><invite>\n");
-		sb.append(MessageFormat.format("<address>ssh://{0}@{1}:{2,number,0}/</address>\n", user.username, host, sshPort));
+		sb.append(MessageFormat.format("<address>ssh://{0}@{1}:{2,number,0}/</address>\n", user.username, sshDisplayHost, sshDisplayPort));
 		sb.append(MessageFormat.format("<remote_path>/{0}</remote_path>\n", model.name));
 		int fanoutPort = settings.getInteger(Keys.fanout.port, 0);
 		if (fanoutPort > 0) {

--- a/src/main/java/com/gitblit/servlet/SparkleShareInviteServlet.java
+++ b/src/main/java/com/gitblit/servlet/SparkleShareInviteServlet.java
@@ -108,7 +108,10 @@ public class SparkleShareInviteServlet extends DaggerServlet {
 		if (!StringUtils.isEmpty(url) && url.indexOf("localhost") == -1) {
 			host = new URL(url).getHost();
 		}
-		String sshDisplayHost = settings.getString(Keys.git.sshDisplayHost, host);
+		String sshDisplayHost = settings.getString(Keys.git.sshDisplayHost, "");
+		if(sshDisplayHost.isEmpty()) {
+			sshDisplayHost = host;
+		}
 
 		UserModel user;
 		if (StringUtils.isEmpty(username)) {

--- a/src/main/java/com/gitblit/transport/ssh/SshDaemon.java
+++ b/src/main/java/com/gitblit/transport/ssh/SshDaemon.java
@@ -143,14 +143,20 @@ public class SshDaemon {
 	}
 
 	public String formatUrl(String gituser, String servername, String repository) {
-		if (sshd.getPort() == DEFAULT_PORT) {
+		IStoredSettings settings = gitblit.getSettings();
+
+		int port = sshd.getPort();
+		int displayPort = settings.getInteger(Keys.git.sshDisplayPort, port);
+		String displayServername = settings.getString(Keys.git.sshDisplayHost, servername);
+
+		if (displayPort == DEFAULT_PORT) {
 			// standard port
-			return MessageFormat.format("ssh://{0}@{1}/{2}", gituser, servername,
-					repository);
+			return MessageFormat.format("ssh://{0}@{1}/{2}", gituser, displayServername,
+						    repository);
 		} else {
 			// non-standard port
 			return MessageFormat.format("ssh://{0}@{1}:{2,number,0}/{3}",
-					gituser, servername, sshd.getPort(), repository);
+						    gituser, displayServername, displayPort, repository);
 		}
 	}
 

--- a/src/main/java/com/gitblit/transport/ssh/SshDaemon.java
+++ b/src/main/java/com/gitblit/transport/ssh/SshDaemon.java
@@ -147,16 +147,18 @@ public class SshDaemon {
 
 		int port = sshd.getPort();
 		int displayPort = settings.getInteger(Keys.git.sshDisplayPort, port);
-		String displayServername = settings.getString(Keys.git.sshDisplayHost, servername);
-
+		String displayServername = settings.getString(Keys.git.sshDisplayHost, "");
+		if(displayServername.isEmpty()) {
+			displayServername = servername;
+		}
 		if (displayPort == DEFAULT_PORT) {
 			// standard port
 			return MessageFormat.format("ssh://{0}@{1}/{2}", gituser, displayServername,
-						    repository);
+					repository);
 		} else {
 			// non-standard port
 			return MessageFormat.format("ssh://{0}@{1}:{2,number,0}/{3}",
-						    gituser, displayServername, displayPort, repository);
+					gituser, displayServername, displayPort, repository);
 		}
 	}
 

--- a/src/main/java/com/gitblit/transport/ssh/WelcomeShell.java
+++ b/src/main/java/com/gitblit/transport/ssh/WelcomeShell.java
@@ -200,13 +200,15 @@ public class WelcomeShell implements Factory<Command> {
 		}
 
 		private String formatUrl(String hostname, int port, String username) {
-			if (port == 22) {
+			int displayPort = settings.getInteger(Keys.git.sshDisplayPort, port);
+			String displayHostname = settings.getString(Keys.git.sshDisplayHost, hostname);
+			if (displayPort == 22) {
 				// standard port
-				return MessageFormat.format("{0}@{1}/REPOSITORY.git", username, hostname);
+				return MessageFormat.format("{0}@{1}/REPOSITORY.git", username, displayHostname);
 			} else {
 				// non-standard port
 				return MessageFormat.format("ssh://{0}@{1}:{2,number,0}/REPOSITORY.git",
-						username, hostname, port);
+						username, displayHostname, displayPort);
 			}
 		}
 	}

--- a/src/main/java/com/gitblit/transport/ssh/WelcomeShell.java
+++ b/src/main/java/com/gitblit/transport/ssh/WelcomeShell.java
@@ -201,7 +201,10 @@ public class WelcomeShell implements Factory<Command> {
 
 		private String formatUrl(String hostname, int port, String username) {
 			int displayPort = settings.getInteger(Keys.git.sshDisplayPort, port);
-			String displayHostname = settings.getString(Keys.git.sshDisplayHost, hostname);
+			String displayHostname = settings.getString(Keys.git.sshDisplayHost, "");
+			if(displayHostname.isEmpty()) {
+				displayHostname = hostname;
+			}
 			if (displayPort == 22) {
 				// standard port
 				return MessageFormat.format("{0}@{1}/REPOSITORY.git", username, displayHostname);

--- a/src/main/java/com/gitblit/transport/ssh/commands/SshCommand.java
+++ b/src/main/java/com/gitblit/transport/ssh/commands/SshCommand.java
@@ -74,9 +74,11 @@ public abstract class SshCommand extends BaseCommand {
 
 	protected String getRepositoryUrl(String repository) {
 		String username = getContext().getClient().getUsername();
-		String hostname = getHostname();
 		IStoredSettings settings = getContext().getGitblit().getSettings();
-		String displayHostname = settings.getString(Keys.git.sshDisplayHost, hostname);
+		String displayHostname = settings.getString(Keys.git.sshDisplayHost, "");
+		if(displayHostname.isEmpty()) {
+			displayHostname = getHostname();
+		}
 		int port = settings.getInteger(Keys.git.sshPort, 0);
 		int displayPort = settings.getInteger(Keys.git.sshDisplayPort, port);
 		if (displayPort == 22) {

--- a/src/main/java/com/gitblit/transport/ssh/commands/SshCommand.java
+++ b/src/main/java/com/gitblit/transport/ssh/commands/SshCommand.java
@@ -16,6 +16,7 @@
  */
 package com.gitblit.transport.ssh.commands;
 
+import com.gitblit.IStoredSettings;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.net.MalformedURLException;
@@ -74,14 +75,17 @@ public abstract class SshCommand extends BaseCommand {
 	protected String getRepositoryUrl(String repository) {
 		String username = getContext().getClient().getUsername();
 		String hostname = getHostname();
-		int port = getContext().getGitblit().getSettings().getInteger(Keys.git.sshPort, 0);
-		if (port == 22) {
+		IStoredSettings settings = getContext().getGitblit().getSettings();
+		String displayHostname = settings.getString(Keys.git.sshDisplayHost, hostname);
+		int port = settings.getInteger(Keys.git.sshPort, 0);
+		int displayPort = settings.getInteger(Keys.git.sshDisplayPort, port);
+		if (displayPort == 22) {
 			// standard port
-			return MessageFormat.format("{0}@{1}/{2}.git", username, hostname, repository);
+			return MessageFormat.format("{0}@{1}/{2}.git", username, displayHostname, repository);
 		} else {
 			// non-standard port
 			return MessageFormat.format("ssh://{0}@{1}:{2,number,0}/{3}",
-					username, hostname, port, repository);
+					username, displayHostname, displayPort, repository);
 		}
 	}
 


### PR DESCRIPTION
I've tried to run gitblit in a docker container, and wanted to run the ssh server on what looks like port 22.
However I didn't want to run it as root. So I exposed the default port as (server's 2nd ip) port 22.
Then I would like an easy way of using this port in the web interface.

So I added git.sshDisplayHost/Port to the config.

----
Commit comment:

Added git.sshDisplay{Port|Host} to hide port forward.

Running gitblit in a container it's easy to expose the ssh on the default port.
Using git.sshDisplayPort/git.sshDisplayHost you can expose the forwarded address
as the official location.