### PR TITLE
Bump to JGit 4.0.0

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -41,14 +41,14 @@
 	<classpathentry kind="lib" path="ext/tracwiki-core-1.4.jar" sourcepath="ext/src/tracwiki-core-1.4.jar" />
 	<classpathentry kind="lib" path="ext/mediawiki-core-1.4.jar" sourcepath="ext/src/mediawiki-core-1.4.jar" />
 	<classpathentry kind="lib" path="ext/confluence-core-1.4.jar" sourcepath="ext/src/confluence-core-1.4.jar" />
-	<classpathentry kind="lib" path="ext/org.eclipse.jgit-3.7.0.201502260915-r.jar" sourcepath="ext/src/org.eclipse.jgit-3.7.0.201502260915-r.jar" />
-	<classpathentry kind="lib" path="ext/jsch-0.1.50.jar" sourcepath="ext/src/jsch-0.1.50.jar" />
+	<classpathentry kind="lib" path="ext/org.eclipse.jgit-4.0.0.201506090130-r.jar" sourcepath="ext/src/org.eclipse.jgit-4.0.0.201506090130-r.jar" />
+	<classpathentry kind="lib" path="ext/jsch-0.1.51.jar" sourcepath="ext/src/jsch-0.1.51.jar" />
 	<classpathentry kind="lib" path="ext/JavaEWAH-0.7.9.jar" sourcepath="ext/src/JavaEWAH-0.7.9.jar" />
 	<classpathentry kind="lib" path="ext/httpclient-4.1.3.jar" sourcepath="ext/src/httpclient-4.1.3.jar" />
 	<classpathentry kind="lib" path="ext/httpcore-4.1.4.jar" sourcepath="ext/src/httpcore-4.1.4.jar" />
 	<classpathentry kind="lib" path="ext/commons-logging-1.1.1.jar" sourcepath="ext/src/commons-logging-1.1.1.jar" />
 	<classpathentry kind="lib" path="ext/commons-codec-1.7.jar" sourcepath="ext/src/commons-codec-1.7.jar" />
-	<classpathentry kind="lib" path="ext/org.eclipse.jgit.http.server-3.7.0.201502260915-r.jar" sourcepath="ext/src/org.eclipse.jgit.http.server-3.7.0.201502260915-r.jar" />
+	<classpathentry kind="lib" path="ext/org.eclipse.jgit.http.server-4.0.0.201506090130-r.jar" sourcepath="ext/src/org.eclipse.jgit.http.server-4.0.0.201506090130-r.jar" />
 	<classpathentry kind="lib" path="ext/bcprov-jdk15on-1.51.jar" sourcepath="ext/src/bcprov-jdk15on-1.51.jar" />
 	<classpathentry kind="lib" path="ext/bcmail-jdk15on-1.51.jar" sourcepath="ext/src/bcmail-jdk15on-1.51.jar" />
 	<classpathentry kind="lib" path="ext/bcpkix-jdk15on-1.51.jar" sourcepath="ext/src/bcpkix-jdk15on-1.51.jar" />
@@ -89,6 +89,8 @@
 	<classpathentry kind="lib" path="ext/selenium-api-2.28.0.jar" sourcepath="ext/src/selenium-api-2.28.0.jar" />
 	<classpathentry kind="lib" path="ext/commons-exec-1.1.jar" sourcepath="ext/src/commons-exec-1.1.jar" />
 	<classpathentry kind="lib" path="ext/platform-3.4.0.jar" sourcepath="ext/src/platform-3.4.0.jar" />
+	<classpathentry kind="lib" path="ext/mockito-core-1.10.19.jar" sourcepath="ext/src/mockito-core-1.10.19.jar" />
+	<classpathentry kind="lib" path="ext/objenesis-2.1.jar" sourcepath="ext/src/objenesis-2.1.jar" />
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER" />
 	<classpathentry kind="src" path="src/main/dagger">
 		<attributes>

--- a/build.moxie
+++ b/build.moxie
@@ -106,7 +106,7 @@ properties: {
   slf4j.version  : 1.7.10
   wicket.version : 1.4.21
   lucene.version : 4.10.0
-  jgit.version   : 3.7.0.201502260915-r
+  jgit.version   : 4.0.0.201506090130-r
   groovy.version : 2.4.1
   bouncycastle.version : 1.51
   selenium.version : 2.28.0

--- a/gitblit.iml
+++ b/gitblit.iml
@@ -408,24 +408,24 @@
       </library>
     </orderEntry>
     <orderEntry type="module-library">
-      <library name="org.eclipse.jgit-3.7.0.201502260915-r.jar">
+      <library name="org.eclipse.jgit-4.0.0.201506090130-r.jar">
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/ext/org.eclipse.jgit-3.7.0.201502260915-r.jar!/" />
+          <root url="jar://$MODULE_DIR$/ext/org.eclipse.jgit-4.0.0.201506090130-r.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/ext/src/org.eclipse.jgit-3.7.0.201502260915-r.jar!/" />
+          <root url="jar://$MODULE_DIR$/ext/src/org.eclipse.jgit-4.0.0.201506090130-r.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library">
-      <library name="jsch-0.1.50.jar">
+      <library name="jsch-0.1.51.jar">
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/ext/jsch-0.1.50.jar!/" />
+          <root url="jar://$MODULE_DIR$/ext/jsch-0.1.51.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/ext/src/jsch-0.1.50.jar!/" />
+          <root url="jar://$MODULE_DIR$/ext/src/jsch-0.1.51.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
@@ -485,13 +485,13 @@
       </library>
     </orderEntry>
     <orderEntry type="module-library">
-      <library name="org.eclipse.jgit.http.server-3.7.0.201502260915-r.jar">
+      <library name="org.eclipse.jgit.http.server-4.0.0.201506090130-r.jar">
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/ext/org.eclipse.jgit.http.server-3.7.0.201502260915-r.jar!/" />
+          <root url="jar://$MODULE_DIR$/ext/org.eclipse.jgit.http.server-4.0.0.201506090130-r.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/ext/src/org.eclipse.jgit.http.server-3.7.0.201502260915-r.jar!/" />
+          <root url="jar://$MODULE_DIR$/ext/src/org.eclipse.jgit.http.server-4.0.0.201506090130-r.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
@@ -930,6 +930,28 @@
         <JAVADOC />
         <SOURCES>
           <root url="jar://$MODULE_DIR$/ext/src/platform-3.4.0.jar!/" />
+        </SOURCES>
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library" scope="TEST">
+      <library name="mockito-core-1.10.19.jar">
+        <CLASSES>
+          <root url="jar://$MODULE_DIR$/ext/mockito-core-1.10.19.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES>
+          <root url="jar://$MODULE_DIR$/ext/src/mockito-core-1.10.19.jar!/" />
+        </SOURCES>
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library" scope="TEST">
+      <library name="objenesis-2.1.jar">
+        <CLASSES>
+          <root url="jar://$MODULE_DIR$/ext/objenesis-2.1.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES>
+          <root url="jar://$MODULE_DIR$/ext/src/objenesis-2.1.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>

--- a/src/main/bugtraq/com/syntevo/bugtraq/BugtraqConfig.java
+++ b/src/main/bugtraq/com/syntevo/bugtraq/BugtraqConfig.java
@@ -214,7 +214,7 @@ public final class BugtraqConfig {
 			}
 			finally {
 				rw.dispose();
-				tw.release();
+				tw.close();
 			}
 
 			if (content == null) {

--- a/src/main/java/com/gitblit/git/PatchsetReceivePack.java
+++ b/src/main/java/com/gitblit/git/PatchsetReceivePack.java
@@ -667,7 +667,7 @@ public class PatchsetReceivePack extends GitblitReceivePack {
 					// identified the missing object earlier before we got control.
 					LOGGER.error("failed to get commit count", e);
 				} finally {
-					walk.release();
+					walk.close();
 				}
 
 				sendError("");
@@ -1078,7 +1078,7 @@ public class PatchsetReceivePack extends GitblitReceivePack {
 			LOGGER.error("failed to get commit count", e);
 			return 0;
 		} finally {
-			walk.release();
+			walk.close();
 		}
 		return count;
 	}

--- a/src/main/java/com/gitblit/service/LuceneService.java
+++ b/src/main/java/com/gitblit/service/LuceneService.java
@@ -615,7 +615,7 @@ public class LuceneService implements Runnable {
 			}
 
 			// finished
-			reader.release();
+			reader.close();
 
 			// commit all changes and reset the searcher
 			config.setInt(CONF_INDEX, null, CONF_VERSION, INDEX_VERSION);

--- a/src/main/java/com/gitblit/servlet/RawServlet.java
+++ b/src/main/java/com/gitblit/servlet/RawServlet.java
@@ -468,7 +468,7 @@ public class RawServlet extends HttpServlet {
 				served = true;
 			}
 		} finally {
-			tw.release();
+			tw.close();
 			rw.dispose();
 		}
 

--- a/src/main/java/com/gitblit/tickets/BranchTicketService.java
+++ b/src/main/java/com/gitblit/tickets/BranchTicketService.java
@@ -297,7 +297,7 @@ public class BranchTicketService extends ITicketService implements RefsChangedLi
 			log.error("failed to read " + file, e);
 		} finally {
 			if (rw != null) {
-				rw.release();
+				rw.close();
 			}
 		}
 		return null;
@@ -353,7 +353,7 @@ public class BranchTicketService extends ITicketService implements RefsChangedLi
 		} catch (IOException e) {
 			log.error("", e);
 		} finally {
-			inserter.release();
+			inserter.close();
 		}
 	}
 
@@ -712,7 +712,7 @@ public class BranchTicketService extends ITicketService implements RefsChangedLi
 			} finally {
 				// release the treewalk
 				if (treeWalk != null) {
-					treeWalk.release();
+					treeWalk.close();
 				}
 			}
 		} finally {
@@ -811,7 +811,7 @@ public class BranchTicketService extends ITicketService implements RefsChangedLi
 			// finish the index
 			builder.finish();
 		} finally {
-			inserter.release();
+			inserter.close();
 		}
 		return newIndex;
 	}
@@ -855,7 +855,7 @@ public class BranchTicketService extends ITicketService implements RefsChangedLi
 			}
 		} finally {
 			if (tw != null) {
-				tw.release();
+				tw.close();
 			}
 		}
 		return list;
@@ -913,10 +913,10 @@ public class BranchTicketService extends ITicketService implements RefsChangedLi
 							rc));
 				}
 			} finally {
-				revWalk.release();
+				revWalk.close();
 			}
 		} finally {
-			odi.release();
+			odi.close();
 		}
 		return success;
 	}

--- a/src/main/java/com/gitblit/utils/CompressionUtils.java
+++ b/src/main/java/com/gitblit/utils/CompressionUtils.java
@@ -132,7 +132,7 @@ public class CompressionUtils {
 		} catch (IOException e) {
 			error(e, repository, "{0} failed to zip files from commit {1}", commit.getName());
 		} finally {
-			tw.release();
+			tw.close();
 			rw.dispose();
 		}
 		return success;
@@ -291,7 +291,7 @@ public class CompressionUtils {
 		} catch (IOException e) {
 			error(e, repository, "{0} failed to {1} stream files from commit {2}", algorithm, commit.getName());
 		} finally {
-			tw.release();
+			tw.close();
 			rw.dispose();
 		}
 		return success;

--- a/src/main/java/com/gitblit/utils/JGitUtils.java
+++ b/src/main/java/com/gitblit/utils/JGitUtils.java
@@ -774,7 +774,7 @@ public class JGitUtils {
 			}
 		} finally {
 			rw.dispose();
-			tw.release();
+			tw.close();
 		}
 		return content;
 	}
@@ -885,7 +885,7 @@ public class JGitUtils {
 		} catch (IOException e) {
 			error(e, repository, "{0} failed to get files for commit {1}", commit.getName());
 		} finally {
-			tw.release();
+			tw.close();
 		}
 		Collections.sort(list);
 		return list;
@@ -942,7 +942,7 @@ public class JGitUtils {
 		} catch (IOException e) {
 			error(e, repository, "{0} failed to get files for commit {1}", commit.getName());
 		} finally {
-			tw.release();
+			tw.close();
 		}
 		Collections.sort(list);
 		return list;
@@ -994,7 +994,7 @@ public class JGitUtils {
 							.getRawMode(0), tw.getObjectId(0).getName(), commit.getId().getName(),
 							ChangeType.ADD));
 				}
-				tw.release();
+				tw.close();
 			} else {
 				RevCommit parent = rw.parseCommit(commit.getParent(0).getId());
 				DiffStatFormatter df = new DiffStatFormatter(commit.getName());
@@ -1049,7 +1049,7 @@ public class JGitUtils {
 			RevCommit start = rw.parseCommit(startRange);
 			RevCommit end = rw.parseCommit(endRange);
 			list.addAll(getFilesInRange(repository, start, end));
-			rw.release();
+			rw.close();
 		} catch (Throwable t) {
 			error(t, repository, "{0} failed to determine files in range {1}..{2}!", startCommit, endCommit);
 		}
@@ -1147,7 +1147,7 @@ public class JGitUtils {
 		} catch (IOException e) {
 			error(e, repository, "{0} failed to get documents for commit {1}", commit.getName());
 		} finally {
-			tw.release();
+			tw.close();
 		}
 		Collections.sort(list);
 		return list;
@@ -2044,7 +2044,7 @@ public class JGitUtils {
 			error(t, repository, "{0} can't find {1} in commit {2}", path, commit.name());
 		} finally {
 			rw.dispose();
-			tw.release();
+			tw.close();
 		}
 		return commitId;
 	}
@@ -2218,10 +2218,10 @@ public class JGitUtils {
 						success = false;
 					}
 				} finally {
-					revWalk.release();
+					revWalk.close();
 				}
 			} finally {
-				odi.release();
+				odi.close();
 			}
 		} catch (Throwable t) {
 			error(t, repository, "Failed to create orphan branch {1} in repository {0}", branchName);
@@ -2412,7 +2412,7 @@ public class JGitUtils {
 			LOGGER.error("Failed to determine canMerge", e);
 		} finally {
 			if (revWalk != null) {
-				revWalk.release();
+				revWalk.close();
 			}
 		}
 		return MergeStatus.NOT_MERGEABLE;
@@ -2498,14 +2498,14 @@ public class JGitUtils {
 					// return the merge commit id
 					return new MergeResult(MergeStatus.MERGED, mergeCommitId.getName());
 				} finally {
-					odi.release();
+					odi.close();
 				}
 			}
 		} catch (IOException e) {
 			LOGGER.error("Failed to merge", e);
 		} finally {
 			if (revWalk != null) {
-				revWalk.release();
+				revWalk.close();
 			}
 		}
 		return new MergeResult(MergeStatus.FAILED, null);

--- a/src/main/java/com/gitblit/utils/RefLogUtils.java
+++ b/src/main/java/com/gitblit/utils/RefLogUtils.java
@@ -294,10 +294,10 @@ public class RefLogUtils {
 								rc));
 					}
 				} finally {
-					revWalk.release();
+					revWalk.close();
 				}
 			} finally {
-				odi.release();
+				odi.close();
 			}
 		} catch (Throwable t) {
 			error(t, repository, "Failed to commit reflog entry to {0}");
@@ -395,12 +395,12 @@ public class RefLogUtils {
 			}
 
 			// release the treewalk
-			treeWalk.release();
+			treeWalk.close();
 
 			// finish temporary in-core index used for this commit
 			dcBuilder.finish();
 		} finally {
-			inserter.release();
+			inserter.close();
 		}
 		return inCoreIndex;
 	}

--- a/src/main/java/com/gitblit/wicket/pages/NewRepositoryPage.java
+++ b/src/main/java/com/gitblit/wicket/pages/NewRepositoryPage.java
@@ -359,14 +359,14 @@ public class NewRepositoryPage extends RootSubPage {
 					}
 				}
 			} finally {
-				revWalk.release();
+				revWalk.close();
 			}
 		} catch (UnsupportedEncodingException e) {
 			logger().error(null, e);
 		} catch (IOException e) {
 			logger().error(null, e);
 		} finally {
-			odi.release();
+			odi.close();
 			db.close();
 		}
 		return success;

--- a/src/main/java/com/gitblit/wicket/panels/HistoryPanel.java
+++ b/src/main/java/com/gitblit/wicket/panels/HistoryPanel.java
@@ -116,7 +116,7 @@ public class HistoryPanel extends BasePanel {
 					}
 				} catch (Exception e) {
 				} finally {
-					tw.release();
+					tw.close();
 				}
 			}
 		}


### PR DESCRIPTION
JGit 4.0.0 fixes a memory leak but introduces a non-compatible change
for closing the RevWalk: before it was release() but now is close()