### PR TITLE
Refactor authentication for servlet HTTP header handler

### DIFF
--- a/src/main/distrib/data/defaults.properties
+++ b/src/main/distrib/data/defaults.properties
@@ -817,6 +817,7 @@ realm.userService = ${baseFolder}/users.conf
 # Valid providers are:
 #
 #    htpasswd
+#    httpheader
 #    ldap
 #    pam
 #    redmine
@@ -1738,6 +1739,42 @@ realm.pam.serviceName = system-auth
 # BASEFOLDER
 # SINCE 1.3.2
 realm.htpasswd.userfile = ${baseFolder}/htpasswd
+
+# The name of the HTTP header containing the user name to trust as authenticated
+# default: none
+#
+# WARNING: only use this mechanism if your requests are coming from a trusted
+#          and secure source such as a self managed reverse proxy!
+#
+# RESTART REQUIRED
+# SINCE 1.7.0
+realm.httpheader.userheader =
+
+# The name of the HTTP header containing the team names of which the user is a member.
+# If this is defined, then only groups from the headers will be available, whereas
+# if this remains undefined, then local groups will be used.
+#
+# This setting requires that you have configured realm.httpheader.userheader.
+#
+# default: none
+#
+# RESTART REQUIRED
+# SINCE 1.7.0
+realm.httpheader.teamheader =
+
+# The regular expression pattern used to separate team names in the team header value
+# default: ,
+#
+# This setting requires that you have configured realm.httpheader.teamheader
+#
+# RESTART REQUIRED
+# SINCE 1.7.0
+realm.httpheader.teamseparator = ,
+
+# Auto-creates user accounts when successfully authenticated based on HTTP headers.
+#
+# SINCE 1.7.0
+realm.httpheader.autoCreateAccounts = false
 
 # Restrict the Salesforce user to members of this org.
 # default: 0 (i.e. do not check the Org ID)

--- a/src/main/java/com/gitblit/ConfigUserService.java
+++ b/src/main/java/com/gitblit/ConfigUserService.java
@@ -890,9 +890,6 @@ public class ConfigUserService implements IUserService {
 					user.displayName = config.getString(USER, username, DISPLAYNAME);
 					user.emailAddress = config.getString(USER, username, EMAILADDRESS);
 					user.accountType = AccountType.fromString(config.getString(USER, username, ACCOUNTTYPE));
-					if (Constants.EXTERNAL_ACCOUNT.equals(user.password) && user.accountType.isLocal()) {
-						user.accountType = AccountType.EXTERNAL;
-					}
 					user.disabled = config.getBoolean(USER, username, DISABLED, false);
 					user.organizationalUnit = config.getString(USER, username, ORGANIZATIONALUNIT);
 					user.organization = config.getString(USER, username, ORGANIZATION);

--- a/src/main/java/com/gitblit/Constants.java
+++ b/src/main/java/com/gitblit/Constants.java
@@ -568,7 +568,7 @@ public class Constants {
 	}
 
 	public static enum AuthenticationType {
-		PUBLIC_KEY, CREDENTIALS, COOKIE, CERTIFICATE, CONTAINER;
+		PUBLIC_KEY, CREDENTIALS, COOKIE, CERTIFICATE, CONTAINER, HTTPHEADER;
 
 		public boolean isStandard() {
 			return ordinal() <= COOKIE.ordinal();
@@ -576,7 +576,7 @@ public class Constants {
 	}
 
 	public static enum AccountType {
-		LOCAL, EXTERNAL, CONTAINER, LDAP, REDMINE, SALESFORCE, WINDOWS, PAM, HTPASSWD;
+		LOCAL, EXTERNAL, CONTAINER, LDAP, REDMINE, SALESFORCE, WINDOWS, PAM, HTPASSWD, HTTPHEADER;
 
 		public static AccountType fromString(String value) {
 			for (AccountType type : AccountType.values()) {

--- a/src/main/java/com/gitblit/Constants.java
+++ b/src/main/java/com/gitblit/Constants.java
@@ -576,7 +576,7 @@ public class Constants {
 	}
 
 	public static enum AccountType {
-		LOCAL, EXTERNAL, CONTAINER, LDAP, REDMINE, SALESFORCE, WINDOWS, PAM, HTPASSWD, HTTPHEADER;
+		LOCAL, CONTAINER, LDAP, REDMINE, SALESFORCE, WINDOWS, PAM, HTPASSWD, HTTPHEADER;
 
 		public static AccountType fromString(String value) {
 			for (AccountType type : AccountType.values()) {

--- a/src/main/java/com/gitblit/auth/AuthenticationProvider.java
+++ b/src/main/java/com/gitblit/auth/AuthenticationProvider.java
@@ -18,11 +18,14 @@ package com.gitblit.auth;
 import java.io.File;
 import java.math.BigInteger;
 
+import javax.servlet.http.HttpServletRequest;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.gitblit.Constants.AccountType;
 import com.gitblit.Constants.Role;
+import com.gitblit.Constants.AuthenticationType;
 import com.gitblit.IStoredSettings;
 import com.gitblit.manager.IRuntimeManager;
 import com.gitblit.manager.IUserManager;
@@ -73,6 +76,8 @@ public abstract class AuthenticationProvider {
 		return serviceName;
 	}
 
+	public abstract AuthenticationType getAuthenticationType();
+
 	protected void setCookie(UserModel user, char [] password) {
 		// create a user cookie
 		if (StringUtils.isEmpty(user.cookie) && !ArrayUtils.isEmpty(password)) {
@@ -116,14 +121,32 @@ public abstract class AuthenticationProvider {
 
 	public abstract void stop();
 
+	/**
+	 * Used to handle requests for requests for pages requiring authentication.
+	 * This allows authentication to occur based on the contents of the request
+	 * itself.
+	 *
+	 * @param httpRequest
+	 * @return
+	 */
+	public abstract UserModel authenticate(HttpServletRequest httpRequest);
+
+	/**
+	 * Used to authentication user/password credentials, both for login form
+	 * and HTTP Basic authentication processing.
+	 *
+	 * @param username
+	 * @param password
+	 * @return
+	 */
 	public abstract UserModel authenticate(String username, char[] password);
 
 	public abstract AccountType getAccountType();
 
 	/**
-	 * Does the user service support changes to credentials?
+	 * Returns true if the users's credentials can be changed.
 	 *
-	 * @return true or false
+	 * @return true if the authentication provider supports credential changes
 	 * @since 1.0.0
 	 */
 	public abstract boolean supportsCredentialChanges();
@@ -132,7 +155,7 @@ public abstract class AuthenticationProvider {
 	 * Returns true if the user's display name can be changed.
 	 *
 	 * @param user
-	 * @return true if the user service supports display name changes
+	 * @return true if the authentication provider supports display name changes
 	 */
 	public abstract boolean supportsDisplayNameChanges();
 
@@ -140,7 +163,7 @@ public abstract class AuthenticationProvider {
 	 * Returns true if the user's email address can be changed.
 	 *
 	 * @param user
-	 * @return true if the user service supports email address changes
+	 * @return true if the authentication provider supports email address changes
 	 */
 	public abstract boolean supportsEmailAddressChanges();
 
@@ -148,7 +171,7 @@ public abstract class AuthenticationProvider {
 	 * Returns true if the user's team memberships can be changed.
 	 *
 	 * @param user
-	 * @return true if the user service supports team membership changes
+	 * @return true if the authentication provider supports team membership changes
 	 */
 	public abstract boolean supportsTeamMembershipChanges();
 
@@ -180,6 +203,16 @@ public abstract class AuthenticationProvider {
     		super(serviceName);
     	}
 
+		@Override
+		public UserModel authenticate(HttpServletRequest httpRequest) {
+			return null;
+		}
+
+		@Override
+		public AuthenticationType getAuthenticationType() {
+			return AuthenticationType.CREDENTIALS;
+		}
+
     	@Override
 		public void stop() {
 
@@ -203,6 +236,11 @@ public abstract class AuthenticationProvider {
 		}
 
 		@Override
+		public UserModel authenticate(HttpServletRequest httpRequest) {
+			return null;
+		}
+
+		@Override
 		public UserModel authenticate(String username, char[] password) {
 			return null;
 		}
@@ -210,6 +248,11 @@ public abstract class AuthenticationProvider {
 		@Override
 		public AccountType getAccountType() {
 			return AccountType.LOCAL;
+		}
+
+		@Override
+		public AuthenticationType getAuthenticationType() {
+			return null;
 		}
 
 		@Override

--- a/src/main/java/com/gitblit/auth/HttpHeaderAuthProvider.java
+++ b/src/main/java/com/gitblit/auth/HttpHeaderAuthProvider.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2015 gitblit.com.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.gitblit.auth;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.gitblit.Constants;
+import com.gitblit.Constants.AccountType;
+import com.gitblit.Constants.AuthenticationType;
+import com.gitblit.Constants.Role;
+import com.gitblit.Keys;
+import com.gitblit.models.TeamModel;
+import com.gitblit.models.UserModel;
+import com.gitblit.utils.StringUtils;
+
+public class HttpHeaderAuthProvider extends AuthenticationProvider {
+
+    protected final Logger logger = LoggerFactory.getLogger(getClass());
+
+    protected String userHeaderName;
+    protected String teamHeaderName;
+    protected String teamHeaderSeparator;
+
+	public HttpHeaderAuthProvider() {
+		super("httpheader");
+	}
+
+	@Override
+	public void setup() {
+		// Load HTTP header configuration
+		userHeaderName = settings.getString(Keys.realm.httpheader.userheader, null);
+		teamHeaderName = settings.getString(Keys.realm.httpheader.teamheader, null);
+		teamHeaderSeparator = settings.getString(Keys.realm.httpheader.teamseparator, ",");
+
+		if (StringUtils.isEmpty(userHeaderName)) {
+			logger.warn("HTTP Header authentication is enabled, but no header is not defined in " + Keys.realm.httpheader.userheader);
+		}
+	}
+
+	@Override
+	public void stop() {}
+
+
+	@Override
+	public UserModel authenticate(HttpServletRequest httpRequest) {
+		// Try to authenticate using custom HTTP header if user header is defined
+		if (!StringUtils.isEmpty(userHeaderName)) {
+			String headerUserName = httpRequest.getHeader(userHeaderName);
+			if (!StringUtils.isEmpty(headerUserName) && !userManager.isInternalAccount(headerUserName)) {
+				// We have a user, try to load team names as well
+				Set<TeamModel> userTeams = new HashSet<>();
+				if (!StringUtils.isEmpty(teamHeaderName)) {
+					String headerTeamValue = httpRequest.getHeader(teamHeaderName);
+					if (!StringUtils.isEmpty(headerTeamValue)) {
+						String[] headerTeamNames = headerTeamValue.split(teamHeaderSeparator);
+						for (String teamName : headerTeamNames) {
+							teamName = teamName.trim();
+							if (!StringUtils.isEmpty(teamName)) {
+								TeamModel team = userManager.getTeamModel(teamName);
+								if (null == team) {
+									// Create teams here so they can marked with the correct AccountType
+									team = new TeamModel(teamName);
+									team.accountType = AccountType.HTTPHEADER;
+									updateTeam(team);
+								}
+								userTeams.add(team);
+							}
+						}
+					}
+				}
+
+				UserModel user = userManager.getUserModel(headerUserName);
+				if (user != null) {
+					// If team header is provided in request, reset all team memberships, even if resetting to empty set
+					if (!StringUtils.isEmpty(teamHeaderName)) {
+						user.teams.clear();
+						user.teams.addAll(userTeams);
+					}
+					updateUser(user);
+					return user;
+				} else if (settings.getBoolean(Keys.realm.httpheader.autoCreateAccounts, false)) {
+					// auto-create user from HTTP header
+					user = new UserModel(headerUserName.toLowerCase());
+					user.displayName = headerUserName;
+					user.password = Constants.EXTERNAL_ACCOUNT;
+					user.accountType = AccountType.HTTPHEADER;
+					user.teams.addAll(userTeams);
+					updateUser(user);
+					return user;
+				}
+			}
+		}
+
+		return null;
+	}
+
+	@Override
+	public UserModel authenticate(String username, char[] password){
+		// Username/password is not supported for HTTP header authentication
+		return null;
+	}
+
+	@Override
+	public AccountType getAccountType() {
+		return AccountType.HTTPHEADER;
+	}
+
+	@Override
+	public AuthenticationType getAuthenticationType() {
+		return AuthenticationType.HTTPHEADER;
+	}
+
+	@Override
+	public boolean supportsCredentialChanges() {
+		return false;
+	}
+
+	@Override
+	public boolean supportsDisplayNameChanges() {
+		return false;
+	}
+
+	@Override
+	public boolean supportsEmailAddressChanges() {
+		return false;
+	}
+
+	@Override
+	public boolean supportsTeamMembershipChanges() {
+		return StringUtils.isEmpty(teamHeaderName);
+	}
+
+	@Override
+	public boolean supportsRoleChanges(UserModel user, Role role) {
+		return true;
+	}
+
+	@Override
+	public boolean supportsRoleChanges(TeamModel team, Role role) {
+		return true;
+	}
+}

--- a/src/main/java/com/gitblit/manager/AuthenticationManager.java
+++ b/src/main/java/com/gitblit/manager/AuthenticationManager.java
@@ -41,6 +41,7 @@ import com.gitblit.Keys;
 import com.gitblit.auth.AuthenticationProvider;
 import com.gitblit.auth.AuthenticationProvider.UsernamePasswordAuthenticationProvider;
 import com.gitblit.auth.HtpasswdAuthProvider;
+import com.gitblit.auth.HttpHeaderAuthProvider;
 import com.gitblit.auth.LdapAuthProvider;
 import com.gitblit.auth.PAMAuthProvider;
 import com.gitblit.auth.RedmineAuthProvider;
@@ -92,6 +93,7 @@ public class AuthenticationManager implements IAuthenticationManager {
 		// map of shortcut provider names
 		providerNames = new HashMap<String, Class<? extends AuthenticationProvider>>();
 		providerNames.put("htpasswd", HtpasswdAuthProvider.class);
+		providerNames.put("httpheader", HttpHeaderAuthProvider.class);
 		providerNames.put("ldap", LdapAuthProvider.class);
 		providerNames.put("pam", PAMAuthProvider.class);
 		providerNames.put("redmine", RedmineAuthProvider.class);
@@ -170,7 +172,11 @@ public class AuthenticationManager implements IAuthenticationManager {
 	}
 
 	/**
-	 * Authenticate a user based on HTTP request parameters.
+	 * Used to handle authentication for page requests.
+	 *
+	 * This allows authentication to occur based on the contents of the request
+	 * itself. If no configured @{AuthenticationProvider}s authenticate succesffully,
+	 * a request for login will be shown.
 	 *
 	 * Authentication by X509Certificate is tried first and then by cookie.
 	 *
@@ -185,7 +191,7 @@ public class AuthenticationManager implements IAuthenticationManager {
 	/**
 	 * Authenticate a user based on HTTP request parameters.
 	 *
-	 * Authentication by servlet container principal, X509Certificate, cookie,
+	 * Authentication by custom HTTP header, servlet container principal, X509Certificate, cookie,
 	 * and finally BASIC header.
 	 *
 	 * @param httpRequest
@@ -312,6 +318,17 @@ public class AuthenticationManager implements IAuthenticationManager {
 					logger.warn(MessageFormat.format("Failed login attempt for {0}, invalid credentials from {1}",
 							username, httpRequest.getRemoteAddr()));
 				}
+			}
+		}
+
+		// Check each configured AuthenticationProvider
+		for (AuthenticationProvider ap : authenticationProviders) {
+			UserModel authedUser = ap.authenticate(httpRequest);
+			if (null != authedUser) {
+				flagSession(httpRequest, ap.getAuthenticationType());
+				logger.debug(MessageFormat.format("{0} authenticated by {1} from {2}",
+						authedUser.username, ap.getServiceName(), httpRequest.getRemoteAddr()));
+				return validateAuthentication(authedUser, ap.getAuthenticationType());
 			}
 		}
 		return null;

--- a/src/main/java/com/gitblit/servlet/AccessRestrictionFilter.java
+++ b/src/main/java/com/gitblit/servlet/AccessRestrictionFilter.java
@@ -225,8 +225,8 @@ public abstract class AccessRestrictionFilter extends AuthenticationFilter {
 					// authenticated request permitted.
 					// pass processing to the restricted servlet.
 					newSession(authenticatedRequest, httpResponse);
-					logger.info(MessageFormat.format("ARF: {0} ({1}) authenticated", fullUrl,
-							HttpServletResponse.SC_CONTINUE));
+					logger.info(MessageFormat.format("ARF: authenticated {0} to {1} ({2})", user.username,
+							fullUrl, HttpServletResponse.SC_CONTINUE));
 					chain.doFilter(authenticatedRequest, httpResponse);
 					return;
 				}

--- a/src/site/setup_authentication.mkd
+++ b/src/site/setup_authentication.mkd
@@ -8,6 +8,7 @@ Gitblit supports additional authentication mechanisms aside from it's internal o
 * Windows authentication
 * PAM authentication
 * Htpasswd authentication
+* HTTP header authentication
 * Redmine auhentication
 * Salesforce.com authentication
 * Servlet container authentication
@@ -100,6 +101,17 @@ Htpasswd authentication allows you to maintain your user credentials in an Apach
 
     realm.authenticationProviders = htpasswd
     realm.htpasswd.userFile = /path/to/htpasswd
+
+### HTTP Header Authentication
+
+HTTP header authentication allows you to use existing authentication performed by a trusted frontend, such as a reverse proxy. Ensure that when used, gitblit is ONLY availabe via the trusted frontend, otherwise it is vulnerable to a user adding the header explicitly.
+
+By default, no user or team header is defined, which results in all authentication failing this mechanism. The user header can also be defined while leaving the team header undefined, which causes users to be authenticated from the headers, but team memberships to be maintained locally.
+
+    realm.httpheader.userheader = REMOTE_USER
+    realm.httpheader.teamheader = X-GitblitExample-GroupNames
+    realm.httpheader.teamseparator = ,
+    realm.httpheader.autoCreateAccounts = false
 
 ### Redmine Authentication
 


### PR DESCRIPTION
I'm working on integrating gitblit behind a reverse web proxy which performs authentication and provides group (team) membership via HTTP headers. As such, I'm trying to write a custom authentication plugin which pulls the user and team membership from the request headers. I wouldn't mind using the users.conf mechanism (ConfigUserService) for the storage of the gitblit specific authorization settings.

My goal is similar to current X509 handling, in that it will need to be verified on every request. I started by doing a proof of concept by hard-wiring it in AuthenticationManager, however I then followed it up with modularizing as in option C below, which I think is a better structured approach, because of the extensibility provided. Both steps are available as separate in sequence commits in this pull request.

The mechanism that I'm envisioning would be very similar to the following that we're using for XWiki:
        https://github.com/xwiki-contrib/xwiki-authenticator-headers

However, I was a bit unsure on the best location hooks to use to wire up a new auth plugin, where I have access to the HTTP request header values. After looking at the code base for a bit, I saw a few options:

        A. Write extension of UsernamePasswordAuthenticationProvider, but ignore the parameter values and pass back a UserModel based just on the request context headers.

I haven't found a way to access the request HTTP headers to perform the auth and verify information from within the AuthenticationProvider.authenticate(String username, char[] password) structure. Furthermore, it seems that this is only used for handling the login form submission, after which the session cookie is used for further requests. I'd like to avoid requiring a cookie at all, and build everything for a stateless session with a lifetime only for the duration of request processing.

        B. Modify existing AuthenticationManager direct handling of servlet authentication

The servlet authenticate() version seems to be called from SessionPage on every load, so that appeared to be a viable option. Wicket pages that inherit from SessionPage call GitblitManager, which in turn calls the servlet authenticate method on IAuthenticationManager. The direct handling of the servlet authenticate request within the AuthenticationManager could be updated to add the header authentication.

            Note that the javadoc for the IAuthenticationManager.authenticate() username/password method includes the following, but IUserService doesn't appear to have any authenticate methods (anymore?).
                * @see IUserService.authenticate(String, char[])

        C. Refactor AuthenticationManager so that the authenticate(HttpServletRequest httpRequest) flavor is pluggable like the username password mechanism. This would seem better than B for flexibility. Even adding the header auth into the existing flow in AuthenticationManager, it doesn't allow an installer to select the order or enabling/disabling of various mechanisms. For example, I want to configure it to only trust my custom headers managed by the proxy, not try X509 or pull values from the REMOTE_USER (as getUserPrincipal does).

It seems straight forward to add the servlet authenticate() overload to AuthenticationProvider, and implementations may provide a simple null returning implementation if they don't support a given authentication path. For now that would mean implementing it in my new plugin, and adding a simple null return to UsernamePasswordAuthenticationProvider.

The AuthenticationProvider provides user and team helper methods that check the checksum before calling the UserManager user/team update methods, but I'm just always blinding calling them directly from AuthenticationManager for every request (several per page load). That works but is quite inefficient on I/O, and making servlet authentication handling pluggable would enable using the helper methods as they currently stand within AuthenticationProvider.

This would also provide the benefit of each servlet mechanism being able to indicate their own support for support{DisplayName,Credential,EmailAddress,TeamMembership}Changes, whereas now it is required to be somewhat awkwardly handled in various permutations in the AuthenticationManager itself. The findProvider behavior of returning the NULL AuthenticationProvider if none other is found gets in the way here.

I'd appreciate any comments, there are a few items that I wasn't sure on, so I've submitted the pull request more as an RFC.
    
1. Should a specific AccountType be created for each provider method (what I've done), or should the existing EXTERNAL type by used?

2. The existing handling for AuthenticationManager uses flagSession which requires the AuthenticationType, so I added that to the AuthenticationProvider abstract, however it wasn't clear which values should be mapped through and how its handling differs from AccountType.

3. I haven't yet converted the existing servlet auth mechanisms to AuthenticationProvider yet, but I think for this to be complete that would need to be done as well. If you're okay with the approach I put together I will do that final conversion.

4. The existing requiresCertificate variant of the authenticate(httpRequest) method becomes a bit odd with the new construct. My thought is that this option ends up more cleanly supported as requiring only the (future reworked) X509AuthProvider loaded in order for the realm.authenticationProviders config value.
            
        For example, setting git.requiresClientCertificate previously would now look like:
                realm.authenticationProviders = x509client

        But optionally providing client cert, but not requiring it, looks something like:
                realm.authenticationProviders = x509client basicauth

        The 1.6.2 default processing order would look like:
                realm.authenticationProviders = container x509client sessioncookie basicauth

5. I'd also like to disable local auth entirely for my installation. The easiest way to do that seems to be move AuthenticationManager.authenticateLocal() away from an internal always executed call, and into an AuthenticationProvider module. Are there some assumptions baked in which I haven't noticed about auth providers being always external vs. local/internal authentication?