### PR TITLE
Allow control over which internal repo URLs to show

### DIFF
--- a/src/main/distrib/data/defaults.properties
+++ b/src/main/distrib/data/defaults.properties
@@ -1168,6 +1168,24 @@ web.forwardSlashCharacter = /
 # SINCE 0.5.0
 web.otherUrls = 
 
+# Should HTTP/HTTPS URLs be displayed if the git servlet is enabled?
+# default: true
+#
+# SINCE 1.7.0
+web.showHttpServletUrls = true
+
+# Should git URLs be displayed if the git daemon is enabled?
+# default: true
+#
+# SINCE 1.7.0
+web.showGitDaemonUrls = true
+
+# Should SSH URLs be displayed if the SSH daemon is enabled?
+# default: true
+#
+# SINCE 1.7.0
+web.showSshDaemonUrls = true
+
 # Should app-specific clone links be displayed for SourceTree, SparkleShare, etc?
 #
 # SINCE 1.3.0

--- a/src/main/java/com/gitblit/manager/ServicesManager.java
+++ b/src/main/java/com/gitblit/manager/ServicesManager.java
@@ -162,7 +162,8 @@ public class ServicesManager implements IServicesManager {
 		List<RepositoryUrl> list = new ArrayList<RepositoryUrl>();
 
 		// http/https url
-		if (settings.getBoolean(Keys.git.enableGitServlet, true)) {
+		if (settings.getBoolean(Keys.git.enableGitServlet, true) &&
+			settings.getBoolean(Keys.web.showHttpServletUrls, true)) {
 			AccessPermission permission = user.getRepositoryPermission(repository).permission;
 			if (permission.exceeds(AccessPermission.NONE)) {
 				Transport transport = Transport.fromString(request.getScheme());
@@ -177,7 +178,8 @@ public class ServicesManager implements IServicesManager {
 
 		// ssh daemon url
 		String sshDaemonUrl = getSshDaemonUrl(request, user, repository);
-		if (!StringUtils.isEmpty(sshDaemonUrl)) {
+		if (!StringUtils.isEmpty(sshDaemonUrl) &&
+			settings.getBoolean(Keys.web.showSshDaemonUrls, true)) {
 			AccessPermission permission = user.getRepositoryPermission(repository).permission;
 			if (permission.exceeds(AccessPermission.NONE)) {
 				if (permission.atLeast(AccessPermission.PUSH) && !acceptsPush(Transport.SSH)) {
@@ -192,7 +194,8 @@ public class ServicesManager implements IServicesManager {
 
 		// git daemon url
 		String gitDaemonUrl = getGitDaemonUrl(request, user, repository);
-		if (!StringUtils.isEmpty(gitDaemonUrl)) {
+		if (!StringUtils.isEmpty(gitDaemonUrl) &&
+				settings.getBoolean(Keys.web.showGitDaemonUrls, true)) {
 			AccessPermission permission = getGitDaemonAccessPermission(user, repository);
 			if (permission.exceeds(AccessPermission.NONE)) {
 				if (permission.atLeast(AccessPermission.PUSH) && !acceptsPush(Transport.GIT)) {


### PR DESCRIPTION
As asked on the list, I have gitblit running behind a proxy and have an external canonical path for repositories. I add them to otherUrls, but as things currently stand, there is no way to inhibit display of internal URLs if the required service is running.

I want to use the GitServlet, but only advertise the URL through an external endpoint.