### PR TITLE
Add version number to WAR jar filename

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -261,7 +261,7 @@
 		</mx:webxml>
 
 		<!-- Gitblit jar -->
-		<mx:jar destfile="${webinf}/lib/gitblit.jar" includeresources="false" />
+		<mx:jar destfile="${webinf}/lib/gitblit-${project.version}.jar" includeresources="false" />
 
 		<!-- Build the WAR file -->
 		<mx:zip basedir="${war.dir}" destfile="${project.targetDirectory}/${distribution.warfile}" compress="true" >


### PR DESCRIPTION
For developing, it's much easier to have a version number annotated on the gitblit jar filename to differentiate with testing, as well as knowing final deployment version if interim. Note that I only changed this for the war, not the GO version since the plumbing around that assumes a consistent filename independent of deployed version.