### PR TITLE
allow internal privilege evaluation external URLs

### DIFF
--- a/src/main/distrib/data/defaults.properties
+++ b/src/main/distrib/data/defaults.properties
@@ -1203,6 +1203,18 @@ web.showGitDaemonUrls = true
 # SINCE 1.7.0
 web.showSshDaemonUrls = true
 
+# Should internal permissions be used for web.otherUrls (external access).
+# If enabled, a user will be offered actions for each "otherUrl" based
+# on the internally managed permissions.
+#
+# Configure with caution: Note that gitblit has no way of knowing if further
+# restrictions are imposed by an external forwarding agent, so this may cause
+# more rights to be advertised than are available. It will not grant additional
+# rights, but may incorrectly offer actions that are unavailable.
+#
+# SINCE 1.7.0
+web.useInternalPermissionsForOtherUrls = false
+
 # Should app-specific clone links be displayed for SourceTree, SparkleShare, etc?
 #
 # SINCE 1.3.0

--- a/src/main/java/com/gitblit/models/RepositoryUrl.java
+++ b/src/main/java/com/gitblit/models/RepositoryUrl.java
@@ -41,8 +41,8 @@ public class RepositoryUrl implements Serializable {
 		this.permission = permission;
 	}
 
-	public boolean isExternal() {
-		return permission == null;
+	public boolean isPermissionKnown() {
+		return permission != null;
 	}
 
 	@Override

--- a/src/main/java/com/gitblit/wicket/pages/TicketPage.java
+++ b/src/main/java/com/gitblit/wicket/pages/TicketPage.java
@@ -752,7 +752,7 @@ public class TicketPage extends RepositoryPage {
 		if (currentPatchset == null) {
 			// no patchset available
 			RepositoryUrl repoUrl = getRepositoryUrl(user, repository);
-			boolean canPropose = repoUrl != null && repoUrl.permission.atLeast(AccessPermission.CLONE) && !UserModel.ANONYMOUS.equals(user);
+			boolean canPropose = repoUrl != null && repoUrl.isPermissionKnown() && repoUrl.permission.atLeast(AccessPermission.CLONE) && !UserModel.ANONYMOUS.equals(user);
 			if (ticket.isOpen() && app().tickets().isAcceptingNewPatchsets(repository) && canPropose) {
 				// ticket & repo will accept a proposal patchset
 				// show the instructions for proposing a patchset


### PR DESCRIPTION
commit c20191fc0931a19bec0df1ab2b56f287e5d8b7c7 enabled support
for hiding internal URLs, but didn't consider that it broke the
evaluation of permissions (used for tickets, etc.), and caused
a NPE on repoUrl.permission when trying to view the TicketPage.

With all internal mechanisms disabled, it would result in the
first URL being external with unknown permissions. This adds an
option to use internal permissions even for external URLs.

Note that this does not grant any additional permissions, but
does offer the option to have gitblit advertise the full set of
what is allowed, even if the external URL imposes additional
restrictions.