### PR TITLE
fix permission capping for HTTP/HTTPS

### DIFF
--- a/src/main/java/com/gitblit/manager/ServicesManager.java
+++ b/src/main/java/com/gitblit/manager/ServicesManager.java
@@ -166,13 +166,14 @@ public class ServicesManager implements IServicesManager {
 			settings.getBoolean(Keys.web.showHttpServletUrls, true)) {
 			AccessPermission permission = user.getRepositoryPermission(repository).permission;
 			if (permission.exceeds(AccessPermission.NONE)) {
-				Transport transport = Transport.fromString(request.getScheme());
+				String repoUrl = getRepositoryUrl(request, username, repository);
+				Transport transport = Transport.fromUrl(repoUrl);
 				if (permission.atLeast(AccessPermission.PUSH) && !acceptsPush(transport)) {
 					// downgrade the repo permission for this transport
 					// because it is not an acceptable PUSH transport
 					permission = AccessPermission.CLONE;
 				}
-				list.add(new RepositoryUrl(getRepositoryUrl(request, username, repository), permission));
+				list.add(new RepositoryUrl(repoUrl, permission));
 			}
 		}
 


### PR DESCRIPTION
Previously used request scheme, but request scheme is unrelated to
the URL being generated. Instead, base the permission capping on the
scheme of the URL itself.