### PR TITLE
fix feed link from user's repository page

### DIFF
--- a/src/main/java/com/gitblit/wicket/panels/ProjectRepositoryPanel.java
+++ b/src/main/java/com/gitblit/wicket/panels/ProjectRepositoryPanel.java
@@ -158,6 +158,7 @@ public class ProjectRepositoryPanel extends BasePanel {
 			add(new Label("repositorySize", localizer.getString("gb.empty", parent)).setEscapeModelStrings(false));
 		}
 
-		add(new ExternalLink("syndication", SyndicationServlet.asLink("", entry.name, null, 0)));
+		add(new ExternalLink("syndication", SyndicationServlet.asLink(getRequest()
+				.getRelativePathPrefixToContextRoot(), entry.name, null, 0)));
 	}
 }


### PR DESCRIPTION
used existing pattern from RepositoryPage.addSyndicationDiscoveryLink(), using getRelativePathPrefixToContextRoot to normalize the link root