### PR TITLE
Emulate mount parameters for non-wicket capability

### DIFF
--- a/src/main/distrib/data/defaults.properties
+++ b/src/main/distrib/data/defaults.properties
@@ -1159,7 +1159,11 @@ web.mountParameters = true
 
 # Some servlet containers (e.g. Tomcat >= 6.0.10) disallow '/' (%2F) encoding
 # in URLs as a security precaution for proxies.  This setting tells Gitblit
-# to preemptively replace '/' with '*' or '!' for url string parameters.
+# to preemptively replace '/' with a different character for url path parameters.
+# Note that '!' will always be accepted as input, however an additional character
+# may also be specified as accepted and to be used for generating links.
+#
+# Recommended characters are '!', ':', or '*'
 #
 # <https://issues.apache.org/jira/browse/WICKET-1303>
 # <http://tomcat.apache.org/security-6.html#Fixed_in_Apache_Tomcat_6.0.10>

--- a/src/main/java/com/gitblit/servlet/AccessRestrictionFilter.java
+++ b/src/main/java/com/gitblit/servlet/AccessRestrictionFilter.java
@@ -69,7 +69,7 @@ public abstract class AccessRestrictionFilter extends AuthenticationFilter {
 	 * @param url
 	 * @return repository name
 	 */
-	protected abstract String extractRepositoryName(String url);
+	protected abstract String extractRepositoryName(HttpServletRequest request);
 
 	/**
 	 * Analyze the url and returns the action of the request.
@@ -141,8 +141,7 @@ public abstract class AccessRestrictionFilter extends AuthenticationFilter {
 		HttpServletRequest httpRequest = (HttpServletRequest) request;
 		HttpServletResponse httpResponse = (HttpServletResponse) response;
 
-		String fullUrl = getFullUrl(httpRequest);
-		String repository = extractRepositoryName(fullUrl);
+		String repository = extractRepositoryName(httpRequest);
 		if (StringUtils.isEmpty(repository)) {
 			httpResponse.setStatus(HttpServletResponse.SC_BAD_REQUEST);
 			return;
@@ -155,6 +154,7 @@ public abstract class AccessRestrictionFilter extends AuthenticationFilter {
 		}
 
 		// Determine if the request URL is restricted
+		String fullUrl = getFullUrl(httpRequest);
 		String fullSuffix = fullUrl.substring(repository.length());
 		String urlRequestType = getUrlRequestAction(fullSuffix);
 

--- a/src/main/java/com/gitblit/servlet/GitFilter.java
+++ b/src/main/java/com/gitblit/servlet/GitFilter.java
@@ -94,8 +94,8 @@ public class GitFilter extends AccessRestrictionFilter {
 	 * @return repository name
 	 */
 	@Override
-	protected String extractRepositoryName(String url) {
-		return GitFilter.getRepositoryName(url);
+	protected String extractRepositoryName(HttpServletRequest httpRequest) {
+		return GitFilter.getRepositoryName(httpRequest.getPathInfo());
 	}
 
 	/**

--- a/src/main/java/com/gitblit/servlet/RawFilter.java
+++ b/src/main/java/com/gitblit/servlet/RawFilter.java
@@ -15,11 +15,14 @@
  */
 package com.gitblit.servlet;
 
+import javax.servlet.http.HttpServletRequest;
+
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 
 import org.eclipse.jgit.lib.Repository;
 
+import com.gitblit.Keys;
 import com.gitblit.Constants.AccessRestrictionType;
 import com.gitblit.manager.IAuthenticationManager;
 import com.gitblit.manager.IRepositoryManager;
@@ -53,30 +56,37 @@ public class RawFilter extends AccessRestrictionFilter {
 	 * @return repository name
 	 */
 	@Override
-	protected String extractRepositoryName(String url) {
-		// get the repository name from the url by finding a known url suffix
-		String repository = "";
-		Repository r = null;
-		int offset = 0;
-		while (r == null) {
-			int slash = url.indexOf('/', offset);
-			if (slash == -1) {
-				repository = url;
-			} else {
-				repository = url.substring(0, slash);
+	protected String extractRepositoryName(HttpServletRequest httpRequest) {
+		String repository = null;
+		if (runtimeManager.getSettings().getBoolean(Keys.web.mountParameters, true)) {
+			// get the repository name from the url by finding a known url suffix
+			String url = httpRequest.getPathInfo().substring(1);
+			char c = runtimeManager.getSettings().getChar(Keys.web.forwardSlashCharacter, '/');
+			url = url.replace('!', '/').replace(c, '/');
+			Repository r = null;
+			int offset = 0;
+			while (r == null) {
+				int slash = url.indexOf('/', offset);
+				if (slash == -1) {
+					repository = url;
+				} else {
+					repository = url.substring(0, slash);
+				}
+				r = repositoryManager.getRepository(repository, false);
+				if (r == null) {
+					// try again
+					offset = slash + 1;
+				} else {
+					// close the repo
+					r.close();
+				}
+				if (repository.equals(url)) {
+					// either only repository in url or no repository found
+					break;
+				}
 			}
-			r = repositoryManager.getRepository(repository, false);
-			if (r == null) {
-				// try again
-				offset = slash + 1;
-			} else {
-				// close the repo
-				r.close();
-			}
-			if (repository.equals(url)) {
-				// either only repository in url or no repository found
-				break;
-			}
+		} else {
+			repository = httpRequest.getParameter("r");
 		}
 		return repository;
 	}

--- a/src/main/java/com/gitblit/wicket/freemarker/templates/FilterableProjectList.fm
+++ b/src/main/java/com/gitblit/wicket/freemarker/templates/FilterableProjectList.fm
@@ -6,7 +6,7 @@
 	</div>
 		
 	<div ng-repeat="item in ${ngList} | filter:query" style="padding: 3px;border-top: 1px solid #ddd;">
-		<a href="project/?p={{item.p}}" title="{{item.i}}"><b>{{item.n}}</b></a>
+		<a href="project/{{item.m}}" title="{{item.i}}"><b>{{item.n}}</b></a>
 		<span class="link hidden-tablet hidden-phone" style="color: #bbb;" title="{{item.d}}">{{item.t}}</span>
 		<span class="pull-right">
 			<span style="padding: 0px 5px;color: #888;font-weight:bold;vertical-align:middle;" wicket:message="title:gb.repositories">{{item.c | number}}</span>

--- a/src/main/java/com/gitblit/wicket/freemarker/templates/FilterableRepositoryList.fm
+++ b/src/main/java/com/gitblit/wicket/freemarker/templates/FilterableRepositoryList.fm
@@ -16,7 +16,7 @@
             <span ng-show="item.y == 3" class="octicon octicon-centered octicon-repo-push"></span>
         </span>
     
-		<a href="summary/?r={{item.r}}" title="{{item.i}}">{{item.p}}<b>{{item.n}}</b></a>
+		<a href="summary/{{item.m}}" title="{{item.i}}">{{item.p}}<b>{{item.n}}</b></a>
 		<span class="link hidden-tablet hidden-phone" style="color: #bbb;" title="{{item.d}}">{{item.t}}</span>
 		<span ng-show="item.s" class="pull-right">
 			<span style="padding: 0px 5px;color: #888;font-weight:bold;vertical-align:middle;">{{item.s | number}} <i style="vertical-align:baseline;" class="iconic-star"></i></span>

--- a/src/main/java/com/gitblit/wicket/panels/FilterableProjectList.java
+++ b/src/main/java/com/gitblit/wicket/panels/FilterableProjectList.java
@@ -108,9 +108,18 @@ public class FilterableProjectList extends BasePanel {
 				// exclude user projects from list
 				continue;
 			}
+
+			String mountParamRepoTarget = null;
+			if (app().settings().getBoolean(Keys.web.mountParameters, true)) {
+				mountParamRepoTarget = proj.name;
+			} else {
+				mountParamRepoTarget = "?p=" + proj.name;
+			}
+
 			ProjectListItem item = new ProjectListItem();
 			item.p = proj.name;
 			item.n = StringUtils.isEmpty(proj.title) ? proj.name : proj.title;
+			item.m = mountParamRepoTarget;
 			item.i = proj.description;
 			item.t = getTimeUtils().timeAgo(proj.lastChange);
 			item.d = df.format(proj.lastChange);
@@ -130,6 +139,7 @@ public class FilterableProjectList extends BasePanel {
 
 		String p; // path
 		String n; // name
+		String m; // link snippet spec adapted for mountedParameter configuration
 		String t; // time ago
 		String d; // last updated
 		String i; // information/description

--- a/src/main/java/com/gitblit/wicket/panels/FilterableRepositoryList.java
+++ b/src/main/java/com/gitblit/wicket/panels/FilterableRepositoryList.java
@@ -116,10 +116,19 @@ public class FilterableRepositoryList extends BasePanel {
 				name = name.substring(name.lastIndexOf('/') + 1);
 			}
 
+			String mountParamRepoTarget = null;
+			if (app().settings().getBoolean(Keys.web.mountParameters, true)) {
+				char c = app().settings().getChar(Keys.web.forwardSlashCharacter, '/');
+				mountParamRepoTarget = (path + name).replace('/',  c);
+			} else {
+				mountParamRepoTarget = "?r=" + path + name;
+			}
+
 			RepoListItem item = new RepoListItem();
 			item.n = name;
 			item.p = path;
 			item.r = repo.name;
+			item.m = mountParamRepoTarget;
 			item.i = repo.description;
 			item.s = app().repositories().getStarCount(repo);
 			item.t = getTimeUtils().timeAgo(repo.lastChange);
@@ -150,6 +159,7 @@ public class FilterableRepositoryList extends BasePanel {
 		String r; // repository
 		String n; // name
 		String p; // project/path
+		String m; // link snippet spec adapted for mountedParameter configuration
 		String t; // time ago
 		String d; // last updated
 		String i; // information/description


### PR DESCRIPTION
Some of the one-off servlets are inconsistent when setting the web.mountParameters. This adds emulation support for having at least the project and repository name switch between query string/path. This eases implementing access control restrictions from an external reverse proxy.