### PR TITLE
provide spacing on the projects page listing

### DIFF
--- a/src/main/java/com/gitblit/wicket/pages/ProjectsPage.html
+++ b/src/main/java/com/gitblit/wicket/pages/ProjectsPage.html
@@ -8,7 +8,7 @@
 <wicket:extend>
 <div class="container">
 	
-	<table class="repositories">
+	<table class="repositories projectlist">
 		<thead>
 			<tr>	
 				<th class="left">

--- a/src/main/resources/gitblit.css
+++ b/src/main/resources/gitblit.css
@@ -1734,7 +1734,11 @@ table.comments td {
 	line-height: 17px;
 }
 
-table.repositories {	
+table.projectlist {
+	margin-top: 10px;
+}
+
+table.repositories {
 	border:1px solid #ddd;
 	border-spacing: 0px;
 	width: 100%;


### PR DESCRIPTION
The projects page was showing the project listing directly under the navbar
with no spacing. This adds spacing to have the elements offset.

The table is showing using the common "repositories" class, however it can't
be changed directly since several other table displays use the same class, and
have adequate top margin spacing. We create a new class for the one-off use
on the projects page.