### PR TITLE
fix isPersonalRepository when user prefix is path

### DIFF
--- a/src/main/java/com/gitblit/utils/ModelUtils.java
+++ b/src/main/java/com/gitblit/utils/ModelUtils.java
@@ -105,7 +105,7 @@ public class ModelUtils
 
 
 	/**
-	 * Exrtract a user's name from a personal repository path.
+	 * Extract a user's name from a personal repository path.
 	 *
 	 * @param path
 	 * 			A project name, a relative path to a repository.
@@ -114,9 +114,10 @@ public class ModelUtils
 	 */
 	public static String getUserNameFromRepoPath(String path)
 	{
-		if ( !isPersonalRepository(path) ) return "";
-
-		return path.substring(userRepoPrefix.length());
+		if (isPersonalRepository(path) && path.length() > userRepoPrefix.length())
+			return path.substring(userRepoPrefix.length());
+		else
+			return "";
 	}
 
 }

--- a/src/main/java/com/gitblit/utils/ModelUtils.java
+++ b/src/main/java/com/gitblit/utils/ModelUtils.java
@@ -78,7 +78,12 @@ public class ModelUtils
 	 */
 	public static boolean isPersonalRepository(String name)
 	{
-		if ( name.startsWith(userRepoPrefix) ) return true;
+		String testUserPrefix = userRepoPrefix;
+
+		if (testUserPrefix.endsWith("/"))
+			testUserPrefix = testUserPrefix.substring(0, testUserPrefix.length() - 1);
+
+		if ( name.startsWith(testUserPrefix) ) return true;
 		return false;
 	}
 

--- a/src/test/java/com/gitblit/tests/ModelUtilsTest.java
+++ b/src/test/java/com/gitblit/tests/ModelUtilsTest.java
@@ -79,6 +79,8 @@ public class ModelUtilsTest extends GitblitUnitTest {
 		ModelUtils.setUserRepoPrefix("users/");
 		reponame = "users/three";
 		assertTrue(ModelUtils.isPersonalRepository(reponame));
+		reponame = "users";
+		assertTrue(ModelUtils.isPersonalRepository(reponame));
 
 		reponame = "project/four";
 		assertFalse(ModelUtils.isPersonalRepository(reponame));

--- a/src/test/java/com/gitblit/tests/ModelUtilsTest.java
+++ b/src/test/java/com/gitblit/tests/ModelUtilsTest.java
@@ -79,6 +79,7 @@ public class ModelUtilsTest extends GitblitUnitTest {
 		ModelUtils.setUserRepoPrefix("users/");
 		reponame = "users/three";
 		assertTrue(ModelUtils.isPersonalRepository(reponame));
+		// Ensure that base project path matching path prefix element is marked as personal
 		reponame = "users";
 		assertTrue(ModelUtils.isPersonalRepository(reponame));
 
@@ -124,6 +125,9 @@ public class ModelUtilsTest extends GitblitUnitTest {
 		ModelUtils.setUserRepoPrefix("users/");
 		reponame = "users/fee";
 		assertEquals("fee", ModelUtils.getUserNameFromRepoPath(reponame));
+		// Ensure that a base project path results in empty username
+		reponame = "users";
+		assertEquals("", ModelUtils.getUserNameFromRepoPath(reponame));
 	}
 
 }


### PR DESCRIPTION
The RepositoryModel uses the ModelUtils.isPersonalRepository by only passing
the project path instead of the entire project name as expected, so update
ModelUtils to handle this case.