### PR TITLE
only log successful ARF processing in debugmode

### DIFF
--- a/src/main/java/com/gitblit/servlet/AccessRestrictionFilter.java
+++ b/src/main/java/com/gitblit/servlet/AccessRestrictionFilter.java
@@ -225,8 +225,10 @@ public abstract class AccessRestrictionFilter extends AuthenticationFilter {
 					// authenticated request permitted.
 					// pass processing to the restricted servlet.
 					newSession(authenticatedRequest, httpResponse);
-					logger.info(MessageFormat.format("ARF: {0} ({1}) authenticated", fullUrl,
-							HttpServletResponse.SC_CONTINUE));
+					if (runtimeManager.isDebugMode()) {
+						logger.info(MessageFormat.format("ARF: {0} ({1}) authenticated", fullUrl,
+								HttpServletResponse.SC_CONTINUE));
+					}
 					chain.doFilter(authenticatedRequest, httpResponse);
 					return;
 				}


### PR DESCRIPTION
be consistent with pattern in the rest of ARF to only log authentication results when running in debug mode