### PR TITLE
Fix tags not properly indexed in Lucene

### DIFF
--- a/src/main/java/com/gitblit/service/LuceneService.java
+++ b/src/main/java/com/gitblit/service/LuceneService.java
@@ -437,7 +437,7 @@ public class LuceneService implements Runnable {
 					// skip non-annotated tags
 					continue;
 				}
-				if (!tags.containsKey(tag.getObjectId().getName())) {
+				if (!tags.containsKey(tag.getReferencedObjectId().getName())) {
 					tags.put(tag.getReferencedObjectId().getName(), new ArrayList<String>());
 				}
 				tags.get(tag.getReferencedObjectId().getName()).add(tag.displayName);


### PR DESCRIPTION
All tags that reference to particular object are stored in a list within a map.
There is a if statement that inits empty list when there are not references
to the current object yet, but the boolean expression checks for the wrong value.