### PR TITLE
prevent session fixation for external authentication

### DIFF
--- a/src/main/java/com/gitblit/Constants.java
+++ b/src/main/java/com/gitblit/Constants.java
@@ -137,7 +137,9 @@ public class Constants {
 
 	public static final String DEVELOP = "develop";
 
-	public static final String AUTHENTICATION_TYPE = "authentication-type";
+	public static final String ATTRIB_AUTHTYPE = NAME + ":authentication-type";
+
+	public static final String ATTRIB_AUTHUSER = NAME + ":authenticated-user";
 
 	public static String getVersion() {
 		String v = Constants.class.getPackage().getImplementationVersion();

--- a/src/main/java/com/gitblit/wicket/pages/RootPage.java
+++ b/src/main/java/com/gitblit/wicket/pages/RootPage.java
@@ -279,7 +279,7 @@ public abstract class RootPage extends BasePage {
 
 			request = ((WebRequest) getRequest()).getHttpServletRequest();
 			response = ((WebResponse) getResponse()).getHttpServletResponse();
-			request.getSession().setAttribute(Constants.AUTHENTICATION_TYPE, AuthenticationType.CREDENTIALS);
+			request.getSession().setAttribute(Constants.ATTRIB_AUTHTYPE, AuthenticationType.CREDENTIALS);
 
 			// Set Cookie
 			app().authentication().setCookie(request, response, user);
@@ -608,8 +608,8 @@ public abstract class RootPage extends BasePage {
 			UserModel user = session.getUser();
 			boolean editCredentials = app().authentication().supportsCredentialChanges(user);
 			HttpServletRequest request = ((WebRequest) getRequest()).getHttpServletRequest();
-			AuthenticationType authenticationType = (AuthenticationType) request.getSession().getAttribute(Constants.AUTHENTICATION_TYPE);
-			boolean standardLogin = authenticationType.isStandard();
+			AuthenticationType authenticationType = (AuthenticationType) request.getAttribute(Constants.ATTRIB_AUTHTYPE);
+			boolean standardLogin = (null != authenticationType) ? authenticationType.isStandard() : true;
 
 			if (app().settings().getBoolean(Keys.web.allowGravatar, true)) {
 				add(new AvatarImage("username", user, "navbarGravatar", 20, false));

--- a/src/main/java/com/gitblit/wicket/pages/SessionPage.java
+++ b/src/main/java/com/gitblit/wicket/pages/SessionPage.java
@@ -56,34 +56,50 @@ public abstract class SessionPage extends WebPage {
 		HttpServletRequest request = ((WebRequest) getRequest()).getHttpServletRequest();
 		HttpServletResponse response = ((WebResponse) getResponse()).getHttpServletResponse();
 
-		if (session.isLoggedIn() && !session.isSessionInvalidated()) {
-			// already have a session, refresh usermodel to pick up
-			// any changes to permissions or roles (issue-186)
-			UserModel user = app().users().getUserModel(session.getUser().username);
+		// If using container/external servlet authentication, use request attribute
+		String authedUser = (String) request.getAttribute(Constants.ATTRIB_AUTHUSER);
 
-			if (user == null || user.disabled) {
-				// user was deleted/disabled during session
-				app().authentication().logout(request, response, user);
-				session.setUser(null);
-				session.invalidateNow();
-				return;
+		// Default to trusting session authentication if not set in request by external processing
+		if (StringUtils.isEmpty(authedUser) && session.isLoggedIn()) {
+			authedUser = session.getUsername();
+		}
+
+		if (!StringUtils.isEmpty(authedUser)) {
+			// Avoid session fixation for non-session authentication
+			// If the authenticated user is different from the session user, discard
+			// the old session entirely, without trusting any session values
+			if (!authedUser.equals(session.getUsername())) {
+				session.replaceSession();
 			}
 
-			// validate cookie during session (issue-361)
-			if (user != null && app().settings().getBoolean(Keys.web.allowCookieAuthentication, true)) {
-				String requestCookie = app().authentication().getCookie(request);
-				if (!StringUtils.isEmpty(requestCookie) && !StringUtils.isEmpty(user.cookie)) {
-					if (!requestCookie.equals(user.cookie)) {
-						// cookie was changed during our session
-						app().authentication().logout(request, response, user);
-						session.setUser(null);
-						session.invalidateNow();
-						return;
+			if (!session.isSessionInvalidated()) {
+				// Refresh usermodel to pick up any changes to permissions or roles (issue-186)
+				UserModel user = app().users().getUserModel(authedUser);
+
+				if (user == null || user.disabled) {
+					// user was deleted/disabled during session
+					app().authentication().logout(request, response, user);
+					session.setUser(null);
+					session.invalidateNow();
+					return;
+				}
+
+				// validate cookie during session (issue-361)
+				if (app().settings().getBoolean(Keys.web.allowCookieAuthentication, true)) {
+					String requestCookie = app().authentication().getCookie(request);
+					if (!StringUtils.isEmpty(requestCookie) && !StringUtils.isEmpty(user.cookie)) {
+						if (!requestCookie.equals(user.cookie)) {
+							// cookie was changed during our session
+							app().authentication().logout(request, response, user);
+							session.setUser(null);
+							session.invalidateNow();
+							return;
+						}
 					}
 				}
+				session.setUser(user);
+				return;
 			}
-			session.setUser(user);
-			return;
 		}
 
 		// try to authenticate by servlet request
@@ -91,9 +107,7 @@ public abstract class SessionPage extends WebPage {
 
 		// Login the user
 		if (user != null) {
-			// preserve the authentication type across session replacement
-			AuthenticationType authenticationType = (AuthenticationType) request.getSession()
-					.getAttribute(Constants.AUTHENTICATION_TYPE);
+			AuthenticationType authenticationType = (AuthenticationType) request.getAttribute(Constants.ATTRIB_AUTHTYPE);
 
 			// issue 62: fix session fixation vulnerability
 			// but only if authentication was done in the container.
@@ -101,10 +115,8 @@ public abstract class SessionPage extends WebPage {
 			// don't like
 			if (AuthenticationType.CONTAINER != authenticationType) {
 				session.replaceSession();
-			}			
+			}
 			session.setUser(user);
-
-			request.getSession().setAttribute(Constants.AUTHENTICATION_TYPE, authenticationType);
 
 			// Set Cookie
 			app().authentication().setCookie(request, response, user);


### PR DESCRIPTION
I found that there is an existing session fixation issue when using external (non-standard as defined by Constants.AuthenticationType.isStandard()).

The issue only currently affects deployments using container and certificate based authentication, when two users are using the same browser session which results in the same session cookie being passed. When the external authentication token changes, the UserModel in the session is never updated to reflect the new user, and the new external user ends up using the first user's session, along with accompanying rights.

I initially tried to address this by updating the UserModel in the session from AuthenticationManager processing of authenticate(username, password). However, since that is called by the filter chain processing, it does not have access to the wicket session, since it's not yet bound to a page (exception below, line numbers may differ from local changes in testing). I'm not very familiar with Wicket, if there's a mechanism to do this I couldn't find it.

java.lang.IllegalStateException: you can only locate or create sessions in the context of a request cycle
    at org.apache.wicket.Session.findOrCreate(Session.java:209)
    at org.apache.wicket.Session.get(Session.java:253)
    at com.gitblit.wicket.GitBlitWebSession.get(GitBlitWebSession.java:160)
    at com.gitblit.manager.AuthenticationManager.authenticate(AuthenticationManager.java:351)
    at com.gitblit.manager.AuthenticationManager.authenticate(AuthenticationManager.java:193)
    at com.gitblit.servlet.EnforceAuthenticationFilter.doFilter(EnforceAuthenticationFilter.java:87)

Even if the above were possible with Wicket, there is still an issue with using an inherently stale session attribute for determining whether a user is logged in and who that user is. As part of this fix, I've instead migrated to use a request attribute for the authentication, since that is cleared and starts fresh for processing of every request. Upon successful authentication, the filter mechanism sets the updated UserModel into the userManager, and sets the request attribute. SessionPage then looks at the request attribute and retrieve the corresponding UserModel from the userManager. If external authentication is not done, it falls back to trusting the existing session. The new request attribute asserts the username that has been authenticated in a less error-prone way (since it's not persisted between individual requests).

There may be a better way to assert from a filter to a page that authentication has successfully been performed and for what user, but the request attribute works for now. If there's another more wicket-friendly way to do it I'm fine with that too.