### PR TITLE
Add "all repositories" parameter

### DIFF
--- a/src/main/java/com/gitblit/wicket/GitBlitWebApp.properties
+++ b/src/main/java/com/gitblit/wicket/GitBlitWebApp.properties
@@ -48,6 +48,7 @@ gb.password = password
 gb.tagger = tagger
 gb.moreHistory = more history...
 gb.difftocurrent = diff to current
+gb.allrepos = in all repositories
 gb.search = search
 gb.searchForAuthor = Search for commits authored by
 gb.searchForCommitter = Search for commits committed by

--- a/src/main/java/com/gitblit/wicket/pages/LuceneSearchPage.html
+++ b/src/main/java/com/gitblit/wicket/pages/LuceneSearchPage.html
@@ -24,6 +24,7 @@
 			<div class="span3">
 				<h3><wicket:message key="gb.repositories"></wicket:message></h3>
 				<select wicket:id="repositories" ></select>
+				<label><input type="checkbox" wicket:id="allrepos" /> <span><wicket:message key="gb.allrepos"></wicket:message></span></label>
 			</div>
 			<div class="span9" style="margin-left:10px">
 				<div>


### PR DESCRIPTION
Currently in Gitblit you must explicitly list all repositories to search in them. This does not allow to conveniently link to search page, for example, from a bugtracker. This patch adds "in all repositories" parameter so you can link to /lucene/?allrepos=1&query=$q or select a checkbox in the UI :)