### PR TITLE
Match longest repository path towards the shortest

### DIFF
--- a/src/main/java/com/gitblit/servlet/RawServlet.java
+++ b/src/main/java/com/gitblit/servlet/RawServlet.java
@@ -161,23 +161,14 @@ public class RawServlet extends DaggerServlet {
 		}
 
 		// determine repository and resource from url
-		String repository = "";
+		String repository = path; 
 		Repository r = null;
-		int offset = 0;
-		while (r == null) {
-			int slash = path.indexOf('/', offset);
-			if (slash == -1) {
-				repository = path;
-			} else {
-				repository = path.substring(0, slash);
-			}
-			offset = ( slash + 1 );
+		int terminator = repository.length();
+		do {
+			repository = repository.substring(0, terminator);
 			r = repositoryManager.getRepository(repository, false);
-			if (repository.equals(path)) {
-				// either only repository in url or no repository found
-				break;
-			}
-		}
+			terminator = repository.lastIndexOf('/');
+		} while (r == null && terminator > -1 );
 
 		ServletContext context = request.getSession().getServletContext();
 


### PR DESCRIPTION
Try to to match longest repository paths first:

mediawiki/extensions/SemanticMediaWiki
mediawiki/extensions
mediawiki

Bug: https://github.com/gitblit/gitblit/issues/949