### PR TITLE
fix for #968 extracting repository from URI

### DIFF
--- a/src/main/java/com/gitblit/servlet/FilestoreServlet.java
+++ b/src/main/java/com/gitblit/servlet/FilestoreServlet.java
@@ -63,7 +63,7 @@ public class FilestoreServlet extends HttpServlet {
 	
 	public static final String GIT_LFS_META_MIME = "application/vnd.git-lfs+json";
 	
-	public static final String REGEX_PATH = "^(.*?)/(r|git)/(.*?)/info/lfs/objects/(batch|" + Constants.REGEX_SHA256 + ")";
+	public static final String REGEX_PATH = "^(.*?)/(r)/(.*?)/info/lfs/objects/(batch|" + Constants.REGEX_SHA256 + ")";
 	public static final int REGEX_GROUP_BASE_URI = 1;
 	public static final int REGEX_GROUP_PREFIX = 2;
 	public static final int REGEX_GROUP_REPOSITORY = 3;


### PR DESCRIPTION
This fix allows the repository to be correctly identified by the `FilestoreServlet` when `server.contextPath = /git`