### PR TITLE
Change Jenkins groovy script for any protocol (git/http/ssh)

### DIFF
--- a/src/main/distrib/data/groovy/jenkins.groovy
+++ b/src/main/distrib/data/groovy/jenkins.groovy
@@ -69,8 +69,11 @@ logger.info("jenkins hook triggered by ${user.username} for ${repository.name}")
 // gitblit.properties or web.xml
 def jenkinsUrl = gitblit.getString('groovy.jenkinsServer', 'http://yourserver/jenkins')
 
+// define the repository base url
+def jenkinsGitbaseurl = gitblit.getString('groovy.jenkinsGitbaseurl', "${url}/r")
+
 // define the trigger url
-def triggerUrl = jenkinsUrl + "/git/notifyCommit?url=${url}/r/${repository.name}"
+def triggerUrl = jenkinsUrl + "/git/notifyCommit?url=" + jenkinsGitbaseurl + "/${repository.name}"
 
 // trigger the build
 new URL(triggerUrl).getContent()


### PR DESCRIPTION
groovy.jenkinsGitbaseurl in gitblit.properties or web.xml can override the http default protocol for the jenkins trigger.

without any parameters in gitblit.properties we use "/git/notifyCommit?url=${url}/r/${repository.name}" as triiger
but the groovy.jenkinsGitbaseurl in gitblit.properties is useful for ssh or any other proto

for exemple:
>  groovy.jenkinsGitbaseurl = ssh://gitblit.example.com:28148

target to  

> triggerUrl = jenkinsUrl + "/git/notifyCommit?url=ssh://gitblit.example.com:28148/${repository.name}" 

instead of 

> triggerUrl = jenkinsUrl + "/git/notifyCommit?url=${url}/r/${repository.name}"