### PR TITLE
Fix for #976 - Filestore links via browser

### DIFF
--- a/src/main/java/com/gitblit/Constants.java
+++ b/src/main/java/com/gitblit/Constants.java
@@ -94,6 +94,10 @@ public class Constants {
 	public static final int LEN_SHORTLOG = 78;
 
 	public static final int LEN_SHORTLOG_REFS = 60;
+	
+	public static final int LEN_FILESTORE_META_MIN = 125;
+	
+	public static final int LEN_FILESTORE_META_MAX = 146;
 
 	public static final String DEFAULT_BRANCH = "default";
 

--- a/src/main/java/com/gitblit/servlet/AccessRestrictionFilter.java
+++ b/src/main/java/com/gitblit/servlet/AccessRestrictionFilter.java
@@ -133,10 +133,11 @@ public abstract class AccessRestrictionFilter extends AuthenticationFilter {
 	/**
 	 * Allows authentication header to be altered based on the action requested
 	 * Default is WWW-Authenticate
+	 * @param httpRequest
 	 * @param action
 	 * @return authentication type header
 	 */
-	protected String getAuthenticationHeader(String action) {
+	protected String getAuthenticationHeader(HttpServletRequest httpRequest, String action) {
 		return "WWW-Authenticate";
 	}
 	
@@ -192,7 +193,7 @@ public abstract class AccessRestrictionFilter extends AuthenticationFilter {
 						logger.info(MessageFormat.format("ARF: CREATE CHALLENGE {0}", fullUrl));
 					}
 					
-					httpResponse.setHeader(getAuthenticationHeader(urlRequestType), CHALLENGE);
+					httpResponse.setHeader(getAuthenticationHeader(httpRequest, urlRequestType), CHALLENGE);
 					httpResponse.sendError(HttpServletResponse.SC_UNAUTHORIZED);
 					return;
 				} else {
@@ -239,7 +240,7 @@ public abstract class AccessRestrictionFilter extends AuthenticationFilter {
 				if (runtimeManager.isDebugMode()) {
 					logger.info(MessageFormat.format("ARF: CHALLENGE {0}", fullUrl));
 				}
-				httpResponse.setHeader(getAuthenticationHeader(urlRequestType), CHALLENGE);
+				httpResponse.setHeader(getAuthenticationHeader(httpRequest, urlRequestType), CHALLENGE);
 				httpResponse.sendError(HttpServletResponse.SC_UNAUTHORIZED);
 				return;
 			} else {

--- a/src/main/java/com/gitblit/servlet/DownloadZipServlet.java
+++ b/src/main/java/com/gitblit/servlet/DownloadZipServlet.java
@@ -22,6 +22,7 @@ import java.util.Date;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletResponse;
@@ -34,6 +35,7 @@ import org.slf4j.LoggerFactory;
 import com.gitblit.Constants;
 import com.gitblit.IStoredSettings;
 import com.gitblit.Keys;
+import com.gitblit.manager.IFilestoreManager;
 import com.gitblit.manager.IRepositoryManager;
 import com.gitblit.utils.CompressionUtils;
 import com.gitblit.utils.JGitUtils;
@@ -57,6 +59,8 @@ public class DownloadZipServlet extends HttpServlet {
 	private IStoredSettings settings;
 
 	private IRepositoryManager repositoryManager;
+	
+	private IFilestoreManager filestoreManager;
 
 	public static enum Format {
 		zip(".zip"), tar(".tar"), gz(".tar.gz"), xz(".tar.xz"), bzip2(".tar.bzip2");
@@ -78,9 +82,10 @@ public class DownloadZipServlet extends HttpServlet {
 	}
 
 	@Inject
-	public DownloadZipServlet(IStoredSettings settings, IRepositoryManager repositoryManager) {
+	public DownloadZipServlet(IStoredSettings settings, IRepositoryManager repositoryManager, IFilestoreManager filestoreManager) {
 		this.settings = settings;
 		this.repositoryManager = repositoryManager;
+		this.filestoreManager = filestoreManager;
 	}
 
 	/**
@@ -169,22 +174,23 @@ public class DownloadZipServlet extends HttpServlet {
 			response.setHeader("Pragma", "no-cache");
 			response.setDateHeader("Expires", 0);
 
+			
 			try {
 				switch (format) {
 				case zip:
-					CompressionUtils.zip(r, basePath, objectId, response.getOutputStream());
+					CompressionUtils.zip(r, filestoreManager, basePath, objectId, response.getOutputStream());
 					break;
 				case tar:
-					CompressionUtils.tar(r, basePath, objectId, response.getOutputStream());
+					CompressionUtils.tar(r, filestoreManager, basePath, objectId, response.getOutputStream());
 					break;
 				case gz:
-					CompressionUtils.gz(r, basePath, objectId, response.getOutputStream());
+					CompressionUtils.gz(r, filestoreManager, basePath, objectId, response.getOutputStream());
 					break;
 				case xz:
-					CompressionUtils.xz(r, basePath, objectId, response.getOutputStream());
+					CompressionUtils.xz(r, filestoreManager, basePath, objectId, response.getOutputStream());
 					break;
 				case bzip2:
-					CompressionUtils.bzip2(r, basePath, objectId, response.getOutputStream());
+					CompressionUtils.bzip2(r, filestoreManager, basePath, objectId, response.getOutputStream());
 					break;
 				}
 

--- a/src/main/java/com/gitblit/servlet/FilestoreServlet.java
+++ b/src/main/java/com/gitblit/servlet/FilestoreServlet.java
@@ -238,7 +238,10 @@ public class FilestoreServlet extends HttpServlet {
 			}
 		} else {
 			response.setStatus(responseObject.error.code);
-			serialize(response, responseObject.error);
+			
+			if (isMetaRequest) {
+				serialize(response, responseObject.error);
+			}
 		}
 	};
 	

--- a/src/main/java/com/gitblit/servlet/GitFilter.java
+++ b/src/main/java/com/gitblit/servlet/GitFilter.java
@@ -102,8 +102,8 @@ public class GitFilter extends AccessRestrictionFilter {
 	}
 
 	/**
-	 * Analyze the url and returns the action of the request. Return values are
-	 * either "/git-receive-pack" or "/git-upload-pack".
+	 * Analyze the url and returns the action of the request. Return values are:
+	 * "/git-receive-pack", "/git-upload-pack" or "/info/lfs".
 	 *
 	 * @param serverUrl
 	 * @return action of the request
@@ -316,18 +316,22 @@ public class GitFilter extends AccessRestrictionFilter {
 	
 	/**
 	 * Git lfs action uses an alternative authentication header, 
+	 * dependent on the viewing method.
 	 * 
+	 * @param httpRequest
 	 * @param action
 	 * @return
 	 */
 	@Override
-	protected String getAuthenticationHeader(String action) {
+	protected String getAuthenticationHeader(HttpServletRequest httpRequest, String action) {
 
 		if (action.equals(gitLfs)) {
-			return "LFS-Authenticate";
+			if (hasContentInRequestHeader(httpRequest, "Accept", FilestoreServlet.GIT_LFS_META_MIME)) {
+				return "LFS-Authenticate";
+			}
 		}
 		
-		return super.getAuthenticationHeader(action);
+		return super.getAuthenticationHeader(httpRequest, action);
 	}
 	
 	/**

--- a/src/main/java/com/gitblit/servlet/RawServlet.java
+++ b/src/main/java/com/gitblit/servlet/RawServlet.java
@@ -364,7 +364,7 @@ public class RawServlet extends HttpServlet {
 					if (pathEntries.get(0).path.indexOf('/') > -1) {
 						// we are in a subdirectory, add parent directory link
 						String pp = URLEncoder.encode(requestedPath, Constants.ENCODING);
-						pathEntries.add(0, new PathModel("..", pp + "/..", 0, FileMode.TREE.getBits(), null, null));
+						pathEntries.add(0, new PathModel("..", pp + "/..", null, 0, FileMode.TREE.getBits(), null, null));
 					}
 				}
 

--- a/src/main/java/com/gitblit/utils/DiffStatFormatter.java
+++ b/src/main/java/com/gitblit/utils/DiffStatFormatter.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import org.eclipse.jgit.diff.DiffEntry;
 import org.eclipse.jgit.diff.DiffFormatter;
 import org.eclipse.jgit.diff.RawText;
+import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.util.io.NullOutputStream;
 
 import com.gitblit.models.PathModel.PathChangeModel;
@@ -37,9 +38,9 @@ public class DiffStatFormatter extends DiffFormatter {
 
 	private PathChangeModel path;
 
-	public DiffStatFormatter(String commitId) {
+	public DiffStatFormatter(String commitId, Repository repository) {
 		super(NullOutputStream.INSTANCE);
-		diffStat = new DiffStat(commitId);
+		diffStat = new DiffStat(commitId, repository);
 	}
 
 	@Override

--- a/src/main/java/com/gitblit/utils/DiffUtils.java
+++ b/src/main/java/com/gitblit/utils/DiffUtils.java
@@ -157,13 +157,16 @@ public class DiffUtils {
 		public final List<PathChangeModel> paths = new ArrayList<PathChangeModel>();
 
 		private final String commitId;
+		
+		private final Repository repository;
 
-		public DiffStat(String commitId) {
+		public DiffStat(String commitId, Repository repository) {
 			this.commitId = commitId;
+			this.repository = repository;
 		}
 
 		public PathChangeModel addPath(DiffEntry entry) {
-			PathChangeModel pcm = PathChangeModel.from(entry, commitId);
+			PathChangeModel pcm = PathChangeModel.from(entry, commitId, repository);
 			paths.add(pcm);
 			return pcm;
 		}
@@ -379,7 +382,7 @@ public class DiffUtils {
 			DiffFormatter df;
 			switch (outputType) {
 			case HTML:
-				df = new GitBlitDiffFormatter(commit.getName(), path, handler, tabLength);
+				df = new GitBlitDiffFormatter(commit.getName(), repository, path, handler, tabLength);
 				break;
 			case PLAIN:
 			default:
@@ -548,7 +551,7 @@ public class DiffUtils {
 		DiffStat stat = null;
 		try {
 			RawTextComparator cmp = RawTextComparator.DEFAULT;
-			DiffStatFormatter df = new DiffStatFormatter(commit.getName());
+			DiffStatFormatter df = new DiffStatFormatter(commit.getName(), repository);
 			df.setRepository(repository);
 			df.setDiffComparator(cmp);
 			df.setDetectRenames(true);

--- a/src/main/java/com/gitblit/utils/GitBlitDiffFormatter.java
+++ b/src/main/java/com/gitblit/utils/GitBlitDiffFormatter.java
@@ -33,6 +33,7 @@ import org.eclipse.jgit.diff.DiffEntry;
 import org.eclipse.jgit.diff.DiffEntry.ChangeType;
 import org.eclipse.jgit.diff.DiffFormatter;
 import org.eclipse.jgit.diff.RawText;
+import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.util.RawParseUtils;
 
 import com.gitblit.models.PathModel.PathChangeModel;
@@ -164,11 +165,11 @@ public class GitBlitDiffFormatter extends DiffFormatter {
 
 	}
 
-	public GitBlitDiffFormatter(String commitId, String path, BinaryDiffHandler handler, int tabLength) {
+	public GitBlitDiffFormatter(String commitId, Repository repository, String path, BinaryDiffHandler handler, int tabLength) {
 		super(new DiffOutputStream());
 		this.os = (DiffOutputStream) getOutputStream();
 		this.os.setFormatter(this, handler);
-		this.diffStat = new DiffStat(commitId);
+		this.diffStat = new DiffStat(commitId, repository);
 		this.tabLength = tabLength;
 		// If we have a full commitdiff, install maxima to avoid generating a super-long diff listing that
 		// will only tax the browser too much.

--- a/src/main/java/com/gitblit/wicket/pages/CommitDiffPage.html
+++ b/src/main/java/com/gitblit/wicket/pages/CommitDiffPage.html
@@ -45,6 +45,7 @@
 			<td class="changeType"><span wicket:id="changeType">[change type]</span></td>		
 			<td class="path"><span wicket:id="pathName">[commit path]</span></td>			
 			<td class="hidden-phone rightAlign">
+				<span wicket:id="filestore" style="margin-right:20px;" class="aui-lozenge aui-lozenge-moved"></span>
 				<span class="hidden-tablet" style="padding-right:20px;" wicket:id="diffStat"></span>
 				<span class="link">
 					<span class="hidden-tablet"><a wicket:id="patch"><wicket:message key="gb.patch"></wicket:message></a> | </span><a wicket:id="view"><wicket:message key="gb.view"></wicket:message></a><span class="hidden-tablet"> | <a wicket:id="raw"><wicket:message key="gb.raw"></wicket:message></a></span> | <a wicket:id="blame"><wicket:message key="gb.blame"></wicket:message></a> | <a wicket:id="history"><wicket:message key="gb.history"></wicket:message></a>

--- a/src/main/java/com/gitblit/wicket/pages/CommitPage.html
+++ b/src/main/java/com/gitblit/wicket/pages/CommitPage.html
@@ -77,8 +77,9 @@
 	<table class="pretty">
 		<tr wicket:id="changedPath">
 			<td class="changeType"><span wicket:id="changeType">[change type]</span></td>
-			<td class="path"><span wicket:id="pathName">[commit path]</span></td>			
+			<td class="path"><span wicket:id="pathName">[commit path]</span></td>	
 			<td class="hidden-phone rightAlign">
+				<span wicket:id="filestore" style="margin-right:20px;" class="aui-lozenge aui-lozenge-moved"></span>
 				<span class="hidden-tablet" style="padding-right:20px;" wicket:id="diffStat"></span>
 				<span class="link">
 					<a wicket:id="diff"><wicket:message key="gb.diff"></wicket:message></a> | <span class="hidden-tablet"><a wicket:id="view"><wicket:message key="gb.view"></wicket:message></a> | <a wicket:id="raw"><wicket:message key="gb.raw"></wicket:message></a> | </span><a wicket:id="blame"><wicket:message key="gb.blame"></wicket:message></a> | <a wicket:id="history"><wicket:message key="gb.history"></wicket:message></a>

--- a/src/main/java/com/gitblit/wicket/pages/FilestorePage.java
+++ b/src/main/java/com/gitblit/wicket/pages/FilestorePage.java
@@ -35,7 +35,6 @@ import com.gitblit.models.UserModel;
 import com.gitblit.wicket.CacheControl;
 import com.gitblit.wicket.FilestoreUI;
 import com.gitblit.wicket.GitBlitWebSession;
-import com.gitblit.wicket.RequiresAdminRole;
 import com.gitblit.wicket.WicketUtils;
 import com.gitblit.wicket.CacheControl.LastModified;
 

--- a/src/main/java/com/gitblit/wicket/pages/TreePage.html
+++ b/src/main/java/com/gitblit/wicket/pages/TreePage.html
@@ -22,7 +22,8 @@
 	<table style="width:100%" class="pretty">
 		<tr wicket:id="changedPath">
 			<td class="hidden-phone icon"><img wicket:id="pathIcon" /></td>
-			<td><span wicket:id="pathName"></span></td>			
+			<td><span wicket:id="pathName"></span></td>
+			<td class="hidden-phone filestore"><span wicket:id="filestore" class="aui-lozenge aui-lozenge-moved"></span></td>
 			<td class="hidden-phone size"><span wicket:id="pathSize">[path size]</span></td>
 			<td class="hidden-phone mode"><span wicket:id="pathPermissions">[path permissions]</span></td>
 			<td class="treeLinks"><span wicket:id="pathLinks">[path links]</span></td>

--- a/src/main/java/com/gitblit/wicket/panels/HistoryPanel.java
+++ b/src/main/java/com/gitblit/wicket/panels/HistoryPanel.java
@@ -109,7 +109,7 @@ public class HistoryPanel extends BasePanel {
 					tw.setFilter(PathFilterGroup.createFromStrings(Collections.singleton(path)));
 					while (tw.next()) {
 						if (tw.getPathString().equals(path)) {
-							matchingPath = new PathChangeModel(tw.getPathString(), tw.getPathString(), 0, tw
+							matchingPath = new PathChangeModel(tw.getPathString(), tw.getPathString(), null, 0, tw
 								.getRawMode(0), tw.getObjectId(0).getName(), commit.getId().getName(),
 								ChangeType.MODIFY);
 						}

--- a/src/main/resources/gitblit.css
+++ b/src/main/resources/gitblit.css
@@ -1944,6 +1944,12 @@ td.mode {
 	padding-right:15px;
 }
 
+td.filestore {
+	text-align: right;
+	width:1em;
+	padding-right:15px;
+}
+
 td.size {
 	text-align: right;
 	width: 8em;	

--- a/src/test/java/com/gitblit/tests/JGitUtilsTest.java
+++ b/src/test/java/com/gitblit/tests/JGitUtilsTest.java
@@ -585,16 +585,16 @@ public class JGitUtilsTest extends GitblitUnitTest {
 
 	@Test
 	public void testZip() throws Exception {
-		assertFalse(CompressionUtils.zip(null, null, null, null));
+		assertFalse(CompressionUtils.zip(null, null, null, null, null));
 		Repository repository = GitBlitSuite.getHelloworldRepository();
 		File zipFileA = new File(GitBlitSuite.REPOSITORIES, "helloworld.zip");
 		FileOutputStream fosA = new FileOutputStream(zipFileA);
-		boolean successA = CompressionUtils.zip(repository, null, Constants.HEAD, fosA);
+		boolean successA = CompressionUtils.zip(repository, null, null, Constants.HEAD, fosA);
 		fosA.close();
 
 		File zipFileB = new File(GitBlitSuite.REPOSITORIES, "helloworld-java.zip");
 		FileOutputStream fosB = new FileOutputStream(zipFileB);
-		boolean successB = CompressionUtils.zip(repository, "java.java", Constants.HEAD, fosB);
+		boolean successB = CompressionUtils.zip(repository, null, "java.java", Constants.HEAD, fosB);
 		fosB.close();
 
 		repository.close();


### PR DESCRIPTION
+ GitLFS client support
+ FilestoreModel now parses meta file
+ Read meta heading from cache if available
+ Authentication based on accept headers for browser view filestore login
+ PathModel & PathChangeModel now understands filestore items
+ Zip & Rar downloads contain include filestore items
+ Filestore servlet returns LFS JSON error only if accepted by client
+ DiffStat now knows repository to allow identification of filestore items
+ Filestore items identified and returned via view, raw & blob links on
blame, commitDiff, commit and Tree pages