### PR TITLE
Fix authentication failure warning log messages for FEDERATION_USER

### DIFF
--- a/src/main/java/com/gitblit/manager/AuthenticationManager.java
+++ b/src/main/java/com/gitblit/manager/AuthenticationManager.java
@@ -466,6 +466,12 @@ public class AuthenticationManager implements IAuthenticationManager {
 			return null;
 		}
 
+		if (username.equalsIgnoreCase(Constants.FEDERATION_USER)) {
+			// can not authenticate internal FEDERATION_USER at this point
+			// it must be routed to FederationManager
+			return null;
+		}
+		
 		String usernameDecoded = StringUtils.decodeUsername(username);
 		String pw = new String(password);
 		if (StringUtils.isEmpty(pw)) {


### PR DESCRIPTION
The AuthenticationManager did not encounter for FEDERATION_USER and would unnecessarily
generate a lot of failure warning log messages, e.g:

Failed login attempt for $gitblit, invalid credentials from XXX.XX.XX.XX

A simple condition will prematurely return null bypassing the regular authentication path
and immediately make the authentication be routed via FederationManager.