### PR TITLE
Lower log level of servlet authenticate when request is already authenticated

### DIFF
--- a/src/main/java/com/gitblit/manager/AuthenticationManager.java
+++ b/src/main/java/com/gitblit/manager/AuthenticationManager.java
@@ -204,7 +204,7 @@ public class AuthenticationManager implements IAuthenticationManager {
 		// Check if this request has already been authenticated, and trust that instead of re-processing
 		String reqAuthUser = (String) httpRequest.getAttribute(Constants.ATTRIB_AUTHUSER);
 		if (!StringUtils.isEmpty(reqAuthUser)) {
-			logger.warn("Called servlet authenticate when request is already authenticated.");
+			logger.debug("Called servlet authenticate when request is already authenticated.");
 			return userManager.getUserModel(reqAuthUser);
 		}
 


### PR DESCRIPTION
When calling a servlet which has already been authenticated, the server would produce
a lot of superfluous log entries, e.g:

Called servlet authenticate when request is already authenticated.

The log level for this log entry has been lowered down to DEBUG.