### PR TITLE
Fix for #1031 to display error message

### DIFF
--- a/src/main/java/com/gitblit/wicket/pages/RepositoryPage.java
+++ b/src/main/java/com/gitblit/wicket/pages/RepositoryPage.java
@@ -663,14 +663,22 @@ public abstract class RepositoryPage extends RootPage {
 	}
 
 	@Override
+	protected void onInitialize() {
+
+		super.onInitialize();
+
+		// setup page header and footer
+		setupPage(getRepositoryName(), "/ " + getPageName());
+	}
+	
+	@Override
 	protected void onBeforeRender() {
 		// dispose of repository object
 		if (r != null) {
 			r.close();
 			r = null;
 		}
-		// setup page header and footer
-		setupPage(getRepositoryName(), "/ " + getPageName());
+
 		super.onBeforeRender();
 	}
 


### PR DESCRIPTION
Repository pages will now display correct error message rather than show an internal error.