### PR TITLE
Fix build of javadoc in Windows(zh-cn)

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -433,7 +433,7 @@
 		</zip>
 		
 		<!-- Build API JavaDoc jar -->
-		<mx:javadoc destdir="${javadoc.dir}" redirect="true">
+		<mx:javadoc destdir="${javadoc.dir}" charset="utf-8" encoding="utf-8" docencoding="utf-8" redirect="true">
 			<fileset dir="${project.src.dir}" defaultexcludes="yes">
 				<include name="com/gitblit/Constants.java"/>
 				<include name="com/gitblit/GitBlitException.java"/>


### PR DESCRIPTION
Specify encoding of javadoc to "utf-8".
That will fix build of javadoc in Windows zh-cn (and maybe some other locale).
Unknown why javac works well.

Tested with oracle jdk1.8.0_77