### PR TITLE
Fixes #964 - add missing redirect after restoring user in new session

### DIFF
--- a/src/main/java/com/gitblit/wicket/pages/SessionPage.java
+++ b/src/main/java/com/gitblit/wicket/pages/SessionPage.java
@@ -98,6 +98,7 @@ public abstract class SessionPage extends WebPage {
 					}
 				}
 				session.setUser(user);
+				session.continueRequest();
 				return;
 			}
 		}


### PR DESCRIPTION
Hi,

I may have a fix for #964.

If `web.authenticateViewPages` is set to `true`, and when the session is invalidated due to server restart or if the max inactive interval has been reached (default 30mn) :
* `AuthorizationStrategy.isPageAuthorized` save the target url and return `false` for any page except the homepage
* `AuthorizationStrategy.onUnauthorizedInstantiation` redirect _internally_ to the homepage
* `SessionPage.login` restore user informations and the homepage is rendered

It seems it was missing the redirect to the saved target url to render the correct page

Regards