### PR TITLE
fix user effective permission display

### DIFF
--- a/src/main/java/com/gitblit/models/UserModel.java
+++ b/src/main/java/com/gitblit/models/UserModel.java
@@ -133,6 +133,7 @@ public class UserModel implements Principal, Serializable, Comparable<UserModel>
 
 		// include immutable team permissions, being careful to preserve order
 		Set<RegistrantAccessPermission> set = new LinkedHashSet<RegistrantAccessPermission>(list);
+		ArrayList<RegistrantAccessPermission> arrayList = new ArrayList<RegistrantAccessPermission>(list);
 		for (TeamModel team : teams) {
 			for (RegistrantAccessPermission teamPermission : team.getRepositoryPermissions()) {
 				// we can not change an inherited team permission, though we can override
@@ -140,6 +141,18 @@ public class UserModel implements Principal, Serializable, Comparable<UserModel>
 				teamPermission.permissionType = PermissionType.TEAM;
 				teamPermission.source = team.name;
 				teamPermission.mutable = false;
+                if(arrayList.contains(teamPermission) && arrayList.get(arrayList.indexOf(teamPermission)).permissionType != PermissionType.REGEX){
+                    //checking either to replace permission in set or not
+                    if(teamPermission.permission.compareTo(arrayList.get(arrayList.indexOf(teamPermission)).permission) > 0 ){
+                        arrayList.remove(teamPermission);
+                        arrayList.add(teamPermission);
+                        set.remove(teamPermission);
+                        set.add(teamPermission);
+                    }
+                }
+                else{
+                    arrayList.add(teamPermission);
+                }
 				set.add(teamPermission);
 			}
 		}


### PR DESCRIPTION
There was issue if users is in multiple groups, then in access permissions tab under effective was shown only alphabetically first groups permissions, not the greatest ones. Fixed issue by adding some checks if permissions should be replaced in list. Maybe there is better way to fix this issue. (I am not really developer, just SCM engineer)
