### PR TITLE
fixed for git repo link (ln -s ) issue

### DIFF
--- a/src/main/java/com/gitblit/utils/JGitUtils.java
+++ b/src/main/java/com/gitblit/utils/JGitUtils.java
@@ -550,6 +550,9 @@ public class JGitUtils {
 					if (gitDir.equals(file) || gitDir.getParentFile().equals(file)) {
 						// determine repository name relative to base path
 						String repository = FileUtils.getRelativePath(baseFile, file);
+				       if( repository == null ){
+				            repository= file.getName();
+				        }
 						list.add(repository);
 					} else if (searchSubfolders && file.canRead()) {
 						// look for repositories in subfolders


### PR DESCRIPTION
fixed for link a git repo to $GITBLIT_HOME/git
eg:
mkdir /tmp/test.git && cd /tmp/test.git && git  init --bare
ln -s /tmp/test.git $GITBLIT_HOME/git/test.git

===> then resart gitblit ==>

java.lang.NullPointerException
at
com.gitblit.utils.StringUtils.compareRepositoryNames(StringUtils.java:474)
at com.gitblit.utils.StringUtils$1.compare(StringUtils.java:500)
at com.gitblit.utils.StringUtils$1.compare(StringUtils.java:497)
at java.util.TimSort.countRunAndMakeAscending(TimSort.java:324)
at java.util.TimSort.sort(TimSort.java:189)
at java.util.TimSort.sort(TimSort.java:173)
at java.util.Arrays.sort(Arrays.java:659)
at java.util.Collections.sort(Collections.java:217)
at
com.gitblit.utils.StringUtils.sortRepositorynames(StringUtils.java:497)
at com.gitblit.utils.JGitUtils.getRepositoryList(JGitUtils.java:497)
at
com.gitblit.manager.RepositoryManager.getRepositoryList(RepositoryManager.java:540)
at
com.gitblit.manager.RepositoryManager.start(RepositoryManager.java:162)
