### PR TITLE
Option to explicitly enable or disable optional client certificates

### DIFF
--- a/src/main/distrib/data/defaults.properties
+++ b/src/main/distrib/data/defaults.properties
@@ -2059,8 +2059,8 @@ server.storePassword = gitblit
 # authenticate with ssl certificates.  If enabled, only https clients with the
 # a valid client certificate will be able to access Gitblit.
 #
-# If disabled, client certificate authentication is optional and will be tried
-# first before falling-back to form authentication or basic authentication.
+# If disabled, optional client certificate authentication is configurable by
+# server.wantClientCertificates
 #
 # Requiring client certificates to access any of Gitblit may be too extreme,
 # consider this carefully.
@@ -2068,6 +2068,15 @@ server.storePassword = gitblit
 # SINCE 1.2.0
 # RESTART REQUIRED
 server.requireClientCertificates = false
+
+# If enabled, client certificate authentication is optional and will be tried
+# first before falling-back to form authentication or basic authentication.
+#
+# If disabled, no client certificate authentication will be done at all.
+#
+# SINCE 1.8.1
+# RESTART REQUIRED
+server.wantClientCertificates = false
 
 # Port for shutdown monitor to listen on.
 #

--- a/src/main/java/com/gitblit/GitBlitServer.java
+++ b/src/main/java/com/gitblit/GitBlitServer.java
@@ -288,7 +288,7 @@ public class GitBlitServer {
 				if (params.requireClientCertificates) {
 					factory.setNeedClientAuth(true);
 				} else {
-					factory.setWantClientAuth(true);
+					factory.setWantClientAuth((params.wantClientCertificates));
 				}
 
 				ServerConnector connector = new ServerConnector(server, factory);
@@ -596,6 +596,9 @@ public class GitBlitServer {
 
 		@Option(name = "--requireClientCertificates", usage = "Require client X509 certificates for https connections.")
 		public Boolean requireClientCertificates = FILESETTINGS.getBoolean(Keys.server.requireClientCertificates, false);
+
+		@Option(name = "--wantClientCertificates", usage = "Ask for optional client X509 certificate for https connections. Ignored if client certificates are required.")
+		public Boolean wantClientCertificates = FILESETTINGS.getBoolean(Keys.server.wantClientCertificates, false);
 
 		/*
 		 * Setting overrides


### PR DESCRIPTION
Ref #1137 this setting allows you to disable optional client certificate authentification as well.

I've tested this on my server and there's no longer any prompt to pick a user certificate when connecting to the web interface.

You might want to change the wording or the name of the setting to something you see more fit, I just tried matching the _requireClientCertificates_ setting.
