### PR TITLE
Fix disabled links in PagerPanel

### DIFF
--- a/src/main/java/com/gitblit/wicket/pages/BasePage.html
+++ b/src/main/java/com/gitblit/wicket/pages/BasePage.html
@@ -17,6 +17,7 @@
 		<link rel="stylesheet" href="fontawesome/css/font-awesome.min.css"/>
         <link rel="stylesheet" href="octicons/octicons.css"/>
 		<link rel="stylesheet" type="text/css" href="gitblit.css"/>
+		<link rel="stylesheet" type="text/css" href="bootstrap-fixes.css"/>
 	</wicket:head>
 
 	<body>

--- a/src/main/java/com/gitblit/wicket/panels/PagerPanel.java
+++ b/src/main/java/com/gitblit/wicket/panels/PagerPanel.java
@@ -48,7 +48,7 @@ public class PagerPanel extends Panel {
 			deltas = new int[] { -2, -1, 0, 1, 2 };
 		}
 
-		if (totalPages > 0) {
+		if (totalPages > 0 && currentPage > 1) {
 			pages.add(new PageObject("\u2190", currentPage - 1));
 		}
 		for (int delta : deltas) {
@@ -57,7 +57,7 @@ public class PagerPanel extends Panel {
 				pages.add(new PageObject("" + page, page));
 			}
 		}
-		if (totalPages > 0) {
+		if (totalPages > 0 && currentPage < totalPages) {
 			pages.add(new PageObject("\u2192", currentPage + 1));
 		}
 
@@ -75,6 +75,7 @@ public class PagerPanel extends Panel {
 				item.add(link);
 				if (pageItem.page == currentPage || pageItem.page < 1 || pageItem.page > totalPages) {
 					WicketUtils.setCssClass(item, "disabled");
+					link.setEnabled(false);
 				}
 			}
 		};

--- a/src/main/resources/bootstrap-fixes.css
+++ b/src/main/resources/bootstrap-fixes.css
@@ -1,0 +1,25 @@
+/**
+ * Disabled links in a PagerPanel. Bootstrap 2.0.4 only handles <a>, but not <span>. Wicket renders disabled links as spans.
+ * The .pagination rules here are identical to the ones for <a> in bootstrap.css, but for <span>.
+ */
+.pagination span {
+  float: left;
+  padding: 0 14px;
+  line-height: 34px;
+  text-decoration: none;
+  border: 1px solid #ddd;
+  border-left-width: 0;
+}
+
+.pagination li:first-child span {
+  border-left-width: 1px;
+  -webkit-border-radius: 3px 0 0 3px;
+     -moz-border-radius: 3px 0 0 3px;
+          border-radius: 3px 0 0 3px;
+}
+
+.pagination li:last-child span {
+  -webkit-border-radius: 0 3px 3px 0;
+     -moz-border-radius: 0 3px 3px 0;
+          border-radius: 0 3px 3px 0;
+}


### PR DESCRIPTION
Disabled links in the PagerPanel (used on the LuceneSearchPage to page
through search results) were only rendered as "disabled". The links
themselves remained active, which gives strange effects when clicked.
For instance it was possible to move to result pages -1, -2, and so on.

Really disable the links. Add missing CSS rules to have correct styling
as Wicket renders disabled links as spans, not anchors. Include the new
CSS file in BasePage.html. And add the left/right arrows only if not on
the first/last page.