### PR TITLE
Fix LDAP binding strategies

### DIFF
--- a/src/main/distrib/data/defaults.properties
+++ b/src/main/distrib/data/defaults.properties
@@ -1797,6 +1797,10 @@ realm.salesforce.orgId = 0
 realm.ldap.server = ldap://localhost
 
 # Login username for LDAP searches.
+# This is usually a user with permissions to search LDAP users and groups.
+# It must have at least have the permission to search users. If it does not
+# have permission to search groups, the normal user logging in must have
+# the permission in LDAP to search groups.
 # If this value is unspecified, anonymous LDAP login will be used.
 # 
 # e.g. mydomain\\username
@@ -1809,8 +1813,14 @@ realm.ldap.username = cn=Directory Manager
 # SINCE 1.0.0
 realm.ldap.password = password
 
-# Bind pattern for Authentication.
-# Allow to directly authenticate an user without LDAP Searches.
+# Bind pattern for user authentication.
+# Allow to directly authenticate an user without searching for it in LDAP.
+# Use this if the LDAP server does not allow anonymous access and you don't
+# want to use a specific account to run searches. When set, it will override
+# the settings realm.ldap.username and realm.ldap.password.
+# This requires that all relevant user entries are children to the same DN,
+# and that logging users have permission to search for their groups in LDAP.
+# This will disable synchronization as a specific LDAP account is needed for that.
 # 
 # e.g. CN=${username},OU=Users,OU=UserControl,OU=MyOrganization,DC=MyDomain
 #
@@ -1926,6 +1936,9 @@ realm.ldap.email = email
 realm.ldap.uid = uid
 
 # Defines whether to synchronize all LDAP users and teams into the user service
+# This requires either anonymous LDAP access or that a specific account is set
+# in realm.ldap.username and realm.ldap.password, that has permission to read
+# users and groups in LDAP.
 #
 # Valid values: true, false
 # If left blank, false is assumed


### PR DESCRIPTION
Cleaning up the LDAP binding to support clearly defined strategies.

For synchronization, as before, anonymous or a manager account is used.

The default would be to use anonymous or a manager account to search for the user logging in, binding as the user to authenticate her, and then rebind to the previous authorization to search for groups.
To keep backward compatible to the original implementation, if the anonymous/manager bind cannot search teams, a rebind to the user is carried out to search teams under the user authorization.

The option to directly bind and search as the user has been changed to never attempt to bind anonymous or as a manager account if `realm.ldap.bindpattern` is set.

This fixes #920 as well as #247.