### PR TITLE
Set "can admin" permission on LDAP users and teams correctly

### DIFF
--- a/src/test/resources/ldap/users.conf
+++ b/src/test/resources/ldap/users.conf
@@ -10,7 +10,7 @@
 	displayName = Mrs. User Three
 	emailAddress = userthree@gitblit.com
 	accountType = LDAP
-	role = "#admin"
+	role = "#none"
 [user "userfive"]
 	password = "#externalAccount"
 	cookie = 220bafef069b8b399b2597644015b6b0f4667982
@@ -31,7 +31,7 @@
 	displayName = Mr. User Two
 	emailAddress = usertwo@gitblit.com
 	accountType = LDAP
-	role = "#admin"
+	role = "#none"
 [user "basic"]
 	password = MD5:f17aaabc20bfe045075927934fed52d2
 	cookie = dd94709528bb1c83d08f3088d4043f4742891f4f
@@ -63,6 +63,6 @@
 	user = userthree
 	user = userfour
 [team "Git Admins"]
-	role = "#none"
+	role = "#admin"
 	accountType = LOCAL
 	user = usertwo


### PR DESCRIPTION
The canAdmin permission is set on a LDAP user, when the user is listed
in `realm.ldap.admins` or is a member of a team listed in `realm.ldap.admins`.
This leads to inconsistent and surprising behaviour on the EditUser page
when clicking the "can admin" checkbox. Also, the "can admin" checkbox
is disabled, but not checked, for teams that are listed as admin teams.

The new behaviour implemented in this patch makes users and teams from
LDAP match local ones. That means:
* LDAP teams that are listed in `realm.ldap.admins` get the canAdmin
  property set if teams are maintained in LDAP.
* LDAP users that are listed in `realm.ldap.admins` get the canAdmin
  property set if teams are maintained in LDAP.
* LDAP users do not get the canAdmin property set, if they are only a
  member of a team listed in `realm.ldap.admins`.
* The `supportsRoleChanges` method for users and teams of the
  `LdapAuthProvider` unconditially returns false if teams are
  maintained in LDAP, not only for users and teams listed in
  `realm.ldap.admins`.
* Therefore, for all LDAP users and teams the "can admin" checkbox
  is always disabled if teams are maintained in LDAP.