### PR TITLE
Secure cookies

### DIFF
--- a/src/main/java/com/gitblit/GitBlitServer.java
+++ b/src/main/java/com/gitblit/GitBlitServer.java
@@ -375,7 +375,8 @@ public class GitBlitServer {
 		HashSessionManager sessionManager = new HashSessionManager();
 		sessionManager.setHttpOnly(true);
 		// Use secure cookies if only serving https
-		sessionManager.setSecureRequestOnly(params.port <= 0 && params.securePort > 0);
+		sessionManager.setSecureRequestOnly( (params.port <= 0 && params.securePort > 0) ||
+				(params.port > 0 && params.securePort > 0 && settings.getBoolean(Keys.server.redirectToHttpsPort, true)) );
 		rootContext.getSessionHandler().setSessionManager(sessionManager);
 
 		// Ensure there is a defined User Service

--- a/src/main/java/com/gitblit/manager/AuthenticationManager.java
+++ b/src/main/java/com/gitblit/manager/AuthenticationManager.java
@@ -608,6 +608,11 @@ public class AuthenticationManager implements IAuthenticationManager {
 						userCookie = new Cookie(Constants.NAME, cookie);
 						// expire the cookie in 7 days
 						userCookie.setMaxAge((int) TimeUnit.DAYS.toSeconds(7));
+
+						// Set cookies HttpOnly so they are not accessible to JavaScript engines
+						userCookie.setHttpOnly(true);
+						// Set secure cookie if only HTTPS is used
+						userCookie.setSecure(httpsOnly());
 					}
 				}
 				String path = "/";
@@ -621,6 +626,15 @@ public class AuthenticationManager implements IAuthenticationManager {
 			}
 		}
 	}
+
+
+	private boolean httpsOnly() {
+		int port = settings.getInteger(Keys.server.httpPort, 0);
+		int tlsPort = settings.getInteger(Keys.server.httpsPort, 0);
+		return  (port <= 0 && tlsPort > 0) ||
+				(port > 0 && tlsPort > 0 && settings.getBoolean(Keys.server.redirectToHttpsPort, true) );
+	}
+
 
 	/**
 	 * Logout a user.


### PR DESCRIPTION
Gitblit already set the "secure" flag for cookies, i.e. send them only over secured transports, as well as 'httpOnly' flag for the Jetty session cookies already.
With this PR it will also do so for the user authentication cookies.

It will also set the 'secure' flag when HTTP is redirected to HTTPS by Gitblit.