### PR TITLE
Update UserManager to support construction of IUserServices with IRuntimeManager as a constructor parameter

### DIFF
--- a/src/main/java/com/gitblit/IUserService.java
+++ b/src/main/java/com/gitblit/IUserService.java
@@ -26,6 +26,9 @@ import com.gitblit.models.UserModel;
  * Implementations of IUserService control all aspects of UserModel objects and
  * user authentication.
  *
+ * Plugins implementing this interface (which are instantiated during {@link com.gitblit.manager.UserManager#start()}) can provide
+ * a default constructor or might also use {@link IRuntimeManager} as a constructor argument which will be passed automatically then. 
+ *
  * @author James Moger
  *
  */

--- a/src/main/java/com/gitblit/manager/UserManager.java
+++ b/src/main/java/com/gitblit/manager/UserManager.java
@@ -123,7 +123,7 @@ public class UserManager implements IUserManager {
 					service = createUserService(realmFile);
 				} catch (InstantiationException | IllegalAccessException e1) {
                                         logger.error("failed to instantiate user service {}: {}. Trying once again with IRuntimeManager constructor", realm, e1.getMessage());
-				        //try once again with file constructor. this adds support for subclasses of ConfigUserService
+				        //try once again with IRuntimeManager constructor. This adds support for subclasses of ConfigUserService and other custom IUserServices
                                         try {
                                             Constructor<?> constructor = Class.forName(realm).getConstructor(IRuntimeManager.class);
                                             service = (IUserService) constructor.newInstance(runtimeManager);

--- a/src/main/java/com/gitblit/manager/UserManager.java
+++ b/src/main/java/com/gitblit/manager/UserManager.java
@@ -17,6 +17,8 @@ package com.gitblit.manager;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -119,8 +121,15 @@ public class UserManager implements IUserManager {
 					// typical file path configuration
 					File realmFile = runtimeManager.getFileOrFolder(Keys.realm.userService, "${baseFolder}/users.conf");
 					service = createUserService(realmFile);
-				} catch (InstantiationException | IllegalAccessException  e) {
-					logger.error("failed to instantiate user service {}: {}", realm, e.getMessage());
+				} catch (InstantiationException | IllegalAccessException e1) {
+                                        logger.error("failed to instantiate user service {}: {}. Trying once again with IRuntimeManager constructor", realm, e1.getMessage());
+				        //try once again with file constructor. this adds support for subclasses of ConfigUserService
+                                        try {
+                                            Constructor<?> constructor = Class.forName(realm).getConstructor(IRuntimeManager.class);
+                                            service = (IUserService) constructor.newInstance(runtimeManager);
+                                        } catch (NoSuchMethodException | SecurityException | ClassNotFoundException | InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException e2) {
+                                            logger.error("failed to instantiate user service {}: {}", realm, e2.getMessage());
+                                        }
 				}
 			}
 			setUserService(service);

--- a/src/main/java/com/gitblit/manager/UserManager.java
+++ b/src/main/java/com/gitblit/manager/UserManager.java
@@ -121,20 +121,31 @@ public class UserManager implements IUserManager {
 					// typical file path configuration
 					File realmFile = runtimeManager.getFileOrFolder(Keys.realm.userService, "${baseFolder}/users.conf");
 					service = createUserService(realmFile);
-				} catch (InstantiationException | IllegalAccessException e1) {
-                                        logger.error("failed to instantiate user service {}: {}. Trying once again with IRuntimeManager constructor", realm, e1.getMessage());
-				        //try once again with IRuntimeManager constructor. This adds support for subclasses of ConfigUserService and other custom IUserServices
-                                        try {
-                                            Constructor<?> constructor = Class.forName(realm).getConstructor(IRuntimeManager.class);
-                                            service = (IUserService) constructor.newInstance(runtimeManager);
-                                        } catch (NoSuchMethodException | SecurityException | ClassNotFoundException | InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException e2) {
-                                            logger.error("failed to instantiate user service {}: {}", realm, e2.getMessage());
-                                        }
+				} catch (InstantiationException | IllegalAccessException e) {
+					logger.error("failed to instantiate user service {}: {}. Trying once again with IRuntimeManager constructor", realm, e.getMessage());
+					//try once again with IRuntimeManager constructor. This adds support for subclasses of ConfigUserService and other custom IUserServices
+					service = createIRuntimeManagerAwareUserService(realm);
 				}
 			}
 			setUserService(service);
 		}
 		return this;
+	}
+
+	/**
+	 * Tries to create an {@link IUserService} with {@link #runtimeManager} as a constructor parameter
+	 *
+	 * @param realm the class name of the {@link IUserService} to be instantiated
+	 * @return the {@link IUserService} or {@code null} if instantiation fails
+	 */
+	private IUserService createIRuntimeManagerAwareUserService(String realm) {
+		try {
+		    Constructor<?> constructor = Class.forName(realm).getConstructor(IRuntimeManager.class);
+		    return (IUserService) constructor.newInstance(runtimeManager);
+		} catch (NoSuchMethodException | SecurityException | ClassNotFoundException | InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+		    logger.error("failed to instantiate user service {}: {}", realm, e.getMessage());
+			return null;
+		}
 	}
 
 	protected IUserService createUserService(File realmFile) {


### PR DESCRIPTION
In [gitblit-crowd-plugin](https://github.com/pingunaut/gitblit-crowd) I make use of my own subclass of ConfigUserService.
Unfortunatelly i'm not able to get the data directory from the settings during construction, which is quite bad.

A very simple approach of supporting customized IUserServices is implemented in this PR:
Behavior at the moment:
* Try to instantiate an IUserService with default constructor. 
* If class not found ->create ConfigUserService from conf file
* If instantiation fails -> log error (and die... this will cause NullPointerExceptions afterwards

Newly implemented behavior:
* Try to instantiate an IUserService with default constructor. 
* If class not found -> create ConfigUserService from conf file
* If instantiation with default constructor fails -> Try again with constructor having IRuntimeManager as a parameter
* If this instantiation fails also -> log error (and die... this will cause NullPointerExceptions afterwards

This way no further changes in existing UserServices are needed. New implementations will have the possibility to access all application settings by implementing a constructor like the following:
```java
public class MyCoolUserService implements IUserService {
  public MyCoolUserService(IRuntimeManager manager){
    //do whatever you like. you know the runtimeManager now
  }
}
```