### PR TITLE
Documentation  update : "behind apache" also edit "Ajax-Location" header

### DIFF
--- a/src/site/setup_proxy.mkd
+++ b/src/site/setup_proxy.mkd
@@ -47,6 +47,7 @@ ProxyPreserveHost On
 
 # If your httpd frontend is https but you are proxying http Gitblit WAR or GO
 #Header edit Location ^http://([^/]+)/gitblit/ https://$1/gitblit/
+#Header edit Ajax-Location ^http://([^/]+)/gitblit/ https://$1/gitblit/
 
 # Additionally you will want to tell Gitblit the original scheme and port
 #RequestHeader set X-Forwarded-Proto https


### PR DESCRIPTION
In case apache already terminates https and gitblit only receives http.  Using the "New Ticket" function will respond with an "http://..." in the "Ajax-Location" header. So i added the needed "Header edit ...." line to the documentation.