### PR TITLE
Fix #1114 HttpUtils getGitblitURL does not support nonstandard ports

### DIFF
--- a/src/main/java/com/gitblit/utils/HttpUtils.java
+++ b/src/main/java/com/gitblit/utils/HttpUtils.java
@@ -110,7 +110,9 @@ public class HttpUtils {
 		sb.append(host);
 		if (("http".equals(scheme) && port != 80)
 				|| ("https".equals(scheme) && port != 443)) {
-			sb.append(":").append(port);
+			if (!host.endsWith(":" + port)) {
+				sb.append(":").append(port);
+			}
 		}
 		sb.append(context);
 		return sb.toString();


### PR DESCRIPTION
X-Forwarded-Host can contain port number and it is added twice in that situation
This fix just prevent adding port number if it is already there