### PR TITLE
Prevent last column on Tree page from wraping

### DIFF
--- a/src/main/resources/gitblit.css
+++ b/src/main/resources/gitblit.css
@@ -1963,6 +1963,7 @@ td.rightAlign {
 td.treeLinks {
 	text-align: right;
 	width: 13em;
+	white-space: nowrap;
 }
 
 span.help-inline {


### PR DESCRIPTION
With localizations, there can be longer text then 13em so there is a line break.
This fix prevent this line breaking and thus every line has normal height again.