### PR TITLE
Change version to properties

### DIFF
--- a/build.moxie
+++ b/build.moxie
@@ -103,20 +103,41 @@ repositories: central, eclipse-snapshots, eclipse, gitblit
 
 # Convenience properties for dependencies
 properties: {
-  jetty.version  : 9.2.13.v20150730
-  slf4j.version  : 1.7.12
-  wicket.version : 1.4.22
-  lucene.version : 4.10.4
-  jgit.version   : 4.1.1.201511131810-r
-  groovy.version : 2.4.4
-  bouncycastle.version : 1.52
-  selenium.version : 2.28.0
+  jetty.version  : 9.4.2.v20170220
+  slf4j.version  : 1.7.24
+  wicket.version : 7.6.0
+  lucene.version : 6.4.2
+  jgit.version   : 4.6.1.201703071140-r
+  groovy.version : 2.4.9
+  bouncycastle.version : 1.56
+  selenium.version : 3.3.0
   wikitext.version : 1.4
-  sshd.version: 1.0.0
-  mina.version: 2.0.9
-  guice.version : 4.0
+  sshd.version: 1.4.0
+  mina.version: 2.0.16
+  guice.version : 4.1.0
+  rome.version : 1.7.1
+  gson.version : 2.8.0
+  ldapsdk.version : 3.2.1
+  jcalendar.version : 1.4
+  ivy.version : 2.4.0
+  commonscompress.version : 1.13
+  commonsio.version : 2.5
+  forcepartnerapi.version : 39.0.0
+  freemarker.version : 2.3.23
+  wafflejna.version : 1.8.1 
+  libpam4j.version : 1.8
+  args4j.version :  2.33
+  commonscodec.version : 1.10
+  jedis.version : 2.9.0
+  pf4j.version : 1.2.0
+  tikaCore.version : 1.14
+  jsoup.version : 1.10.2
+  junit.version : 1.12
+  mockito.version : 2.7.15
+  jacoco.version : 0.7.9
   # Gitblit maintains a fork of guice-servlet
-  guice-servlet.version : 4.0-gb2
+  # Change from 4.0-gb2 to upstream
+  guice-servlet.version : 4.1
   }
 
 # Dependencies
@@ -163,30 +184,30 @@ dependencies:
 - compile 'org.bouncycastle:bcpkix-jdk15on:${bouncycastle.version}' :war
 - compile 'org.apache.sshd:sshd-core:${sshd.version}' :war !org.easymock
 - compile 'org.apache.mina:mina-core:${mina.version}' :war !org.easymock
-- compile 'rome:rome:0.9' :war :manager :api
-- compile 'com.google.code.gson:gson:2.3.1' :war :fedclient :manager :api
+- compile 'com.rometools:rome:${rome.version}' :war :manager :api
+- compile 'com.google.code.gson:gson:${gson.version}' :war :fedclient :manager :api
 - compile 'org.codehaus.groovy:groovy-all:${groovy.version}' :war
-- compile 'com.unboundid:unboundid-ldapsdk:2.3.8' :war
-- compile 'org.apache.ivy:ivy:2.2.0' :war
-- compile 'com.toedter:jcalendar:1.3.2' :authority
-- compile 'org.apache.commons:commons-compress:1.4.1' :war
-- compile 'commons-io:commons-io:2.2' :war
-- compile 'com.force.api:force-partner-api:24.0.0' :war
-- compile 'org.freemarker:freemarker:2.3.22' :war
-- compile 'com.github.dblock.waffle:waffle-jna:1.7.3' :war
-- compile 'org.kohsuke:libpam4j:1.8' :war
-- compile 'args4j:args4j:2.0.29' :war :fedclient
-- compile 'commons-codec:commons-codec:1.7' :war
-- compile 'redis.clients:jedis:2.6.2' :war
-- compile 'ro.fortsoft.pf4j:pf4j:0.9.0' :war
-- compile 'org.apache.tika:tika-core:1.5' :war
-- compile 'org.jsoup:jsoup:1.7.3' :war
-- test 'junit:junit:4.12'
+- compile 'com.unboundid:unboundid-ldapsdk:${ldapsdk.version}' :war
+- compile 'org.apache.ivy:ivy:${ivy.version}' :war
+- compile 'com.toedter:jcalendar:${jcalendar.version}' :authority
+- compile 'org.apache.commons:commons-compress:${commonscompress.version}' :war
+- compile 'commons-io:commons-io:${commonsio.version}' :war
+- compile 'com.force.api:force-partner-api:${forcepartnerapi.version}' :war
+- compile 'org.freemarker:freemarker:${freemarker.version}' :war
+- compile 'com.github.dblock.waffle:waffle-jna:${wafflejna.version}' :war
+- compile 'org.kohsuke:libpam4j:${libpam4j.version}' :war
+- compile 'args4j:args4j:${args4j.version}' :war :fedclient
+- compile 'commons-codec:commons-codec:${commonscodec.version}' :war
+- compile 'redis.clients:jedis:${jedis.version}' :war
+- compile 'ro.fortsoft.pf4j:pf4j:${pf4j.version}' :war
+- compile 'org.apache.tika:tika-core:${tikaCore.version}' :war
+- compile 'org.jsoup:jsoup:${jsoup.version}' :war
+- test 'junit:junit:${junit.version}'
 # Dependencies for Selenium web page testing
 - test 'org.seleniumhq.selenium:selenium-java:${selenium.version}' @jar
 - test 'org.seleniumhq.selenium:selenium-support:${selenium.version}' @jar
 - test 'org.seleniumhq.selenium:selenium-firefox-driver:${selenium.version}'
-- test 'org.mockito:mockito-core:1.10.19'
+- test 'org.mockito:mockito-core:${mockito.version}'
 # Dependencies with the "build" scope are retrieved
 # and injected into the Ant runtime classpath
-- build 'org.jacoco:org.jacoco.ant:0.7.8'
+- build 'org.jacoco:org.jacoco.ant:${jacoco.version}'


### PR DESCRIPTION
Raise dependencies numbers.

This update raise all dependecies to the last version, some of them will be an major change, and will break this project.
Please take some time to do this, because you are using (2014) old version (bugs, security problems, etc..)

If you see that this will take too much time, you can only upgrade the easy ones at this moment.
Lots of them are only fixes or compatible changes. And shouldn't break..

Like: jetty, slf4j, jgit, groovy, bouncycastle, sshd, mina, guice, gson, ivy, commons-compress, commons-io, freemarker, commons-codec, jedis, jacoco