### PR TITLE
Fixes the 30 seconds timeout when cloning over HTTP

### DIFF
--- a/src/main/distrib/data/defaults.properties
+++ b/src/main/distrib/data/defaults.properties
@@ -2134,6 +2134,13 @@ server.requireClientCertificates = false
 # RESTART REQUIRED
 server.shutdownPort = 8081
 
+# Timeout (in milliseconds) for http and https requests
+# Increase this value if you get java.util.concurrent.TimeoutException errors
+#
+# SINCE 1.9.0
+# RESTART REQUIRED
+server.httpTimeout = 30000
+
 #
 # Gitblit Filestore Settings
 #

--- a/src/main/distrib/data/defaults.properties
+++ b/src/main/distrib/data/defaults.properties
@@ -2134,12 +2134,12 @@ server.requireClientCertificates = false
 # RESTART REQUIRED
 server.shutdownPort = 8081
 
-# Timeout (in milliseconds) for http and https requests
+# Http idle Timeout (in milliseconds) for http and https requests
 # Increase this value if you get java.util.concurrent.TimeoutException errors
 #
 # SINCE 1.9.0
 # RESTART REQUIRED
-server.httpTimeout = 30000
+server.httpIdleTimeout = 30000
 
 #
 # Gitblit Filestore Settings

--- a/src/main/java/com/gitblit/GitBlitServer.java
+++ b/src/main/java/com/gitblit/GitBlitServer.java
@@ -293,7 +293,7 @@ public class GitBlitServer {
 
 				ServerConnector connector = new ServerConnector(server, factory);
 				connector.setSoLingerTime(-1);
-				connector.setIdleTimeout(settings.getLong(Keys.server.httpTimeout, 30000L));
+				connector.setIdleTimeout(settings.getLong(Keys.server.httpIdleTimeout, 30000L));
 				connector.setPort(params.securePort);
 				String bindInterface = settings.getString(Keys.server.httpsBindInterface, null);
 				if (!StringUtils.isEmpty(bindInterface)) {
@@ -330,7 +330,7 @@ public class GitBlitServer {
 
 			ServerConnector connector = new ServerConnector(server, new HttpConnectionFactory(httpConfig));
 			connector.setSoLingerTime(-1);
-			connector.setIdleTimeout(settings.getLong(Keys.server.httpTimeout, 30000L));
+			connector.setIdleTimeout(settings.getLong(Keys.server.httpIdleTimeout, 30000L));
 			connector.setPort(params.port);
 			String bindInterface = settings.getString(Keys.server.httpBindInterface, null);
 			if (!StringUtils.isEmpty(bindInterface)) {

--- a/src/main/java/com/gitblit/GitBlitServer.java
+++ b/src/main/java/com/gitblit/GitBlitServer.java
@@ -293,7 +293,7 @@ public class GitBlitServer {
 
 				ServerConnector connector = new ServerConnector(server, factory);
 				connector.setSoLingerTime(-1);
-				connector.setIdleTimeout(30000);
+				connector.setIdleTimeout(settings.getLong(Keys.server.httpTimeout, 30000L));
 				connector.setPort(params.securePort);
 				String bindInterface = settings.getString(Keys.server.httpsBindInterface, null);
 				if (!StringUtils.isEmpty(bindInterface)) {
@@ -330,7 +330,7 @@ public class GitBlitServer {
 
 			ServerConnector connector = new ServerConnector(server, new HttpConnectionFactory(httpConfig));
 			connector.setSoLingerTime(-1);
-			connector.setIdleTimeout(30000);
+			connector.setIdleTimeout(settings.getLong(Keys.server.httpTimeout, 30000L));
 			connector.setPort(params.port);
 			String bindInterface = settings.getString(Keys.server.httpBindInterface, null);
 			if (!StringUtils.isEmpty(bindInterface)) {


### PR DESCRIPTION
Adds the

`server.httpTimeout`

setting to allow cloning big repositories over HTTP. This change fixes the java.util.concurrent.TimeoutException issue described in https://groups.google.com/d/topic/gitblit/UvDC48NpmF4/discussion .