### PR TITLE
Update new jgit release (4.8.0.201706111038-r)

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -42,15 +42,14 @@
 	<classpathentry kind="lib" path="ext/tracwiki-core-1.4.jar" sourcepath="ext/src/tracwiki-core-1.4.jar" />
 	<classpathentry kind="lib" path="ext/mediawiki-core-1.4.jar" sourcepath="ext/src/mediawiki-core-1.4.jar" />
 	<classpathentry kind="lib" path="ext/confluence-core-1.4.jar" sourcepath="ext/src/confluence-core-1.4.jar" />
-	<classpathentry kind="lib" path="ext/org.eclipse.jgit-4.1.1.201511131810-r.jar" sourcepath="ext/src/org.eclipse.jgit-4.1.1.201511131810-r.jar" />
-	<classpathentry kind="lib" path="ext/jsch-0.1.53.jar" sourcepath="ext/src/jsch-0.1.53.jar" />
-	<classpathentry kind="lib" path="ext/JavaEWAH-0.7.9.jar" sourcepath="ext/src/JavaEWAH-0.7.9.jar" />
+	<classpathentry kind="lib" path="ext/org.eclipse.jgit-4.8.0.201706111038-r.jar" sourcepath="ext/src/org.eclipse.jgit-4.8.0.201706111038-r.jar" />
+	<classpathentry kind="lib" path="ext/jsch-0.1.54.jar" sourcepath="ext/src/jsch-0.1.54.jar" />
+	<classpathentry kind="lib" path="ext/JavaEWAH-1.1.6.jar" sourcepath="ext/src/JavaEWAH-1.1.6.jar" />
 	<classpathentry kind="lib" path="ext/httpclient-4.3.6.jar" sourcepath="ext/src/httpclient-4.3.6.jar" />
 	<classpathentry kind="lib" path="ext/httpcore-4.3.3.jar" sourcepath="ext/src/httpcore-4.3.3.jar" />
 	<classpathentry kind="lib" path="ext/commons-logging-1.1.3.jar" sourcepath="ext/src/commons-logging-1.1.3.jar" />
 	<classpathentry kind="lib" path="ext/commons-codec-1.7.jar" sourcepath="ext/src/commons-codec-1.7.jar" />
-	<classpathentry kind="lib" path="ext/org.eclipse.jdt.annotation-1.1.0.jar" sourcepath="ext/src/org.eclipse.jdt.annotation-1.1.0.jar" />
-	<classpathentry kind="lib" path="ext/org.eclipse.jgit.http.server-4.1.1.201511131810-r.jar" sourcepath="ext/src/org.eclipse.jgit.http.server-4.1.1.201511131810-r.jar" />
+	<classpathentry kind="lib" path="ext/org.eclipse.jgit.http.server-4.8.0.201706111038-r.jar" sourcepath="ext/src/org.eclipse.jgit.http.server-4.8.0.201706111038-r.jar" />
 	<classpathentry kind="lib" path="ext/bcprov-jdk15on-1.52.jar" sourcepath="ext/src/bcprov-jdk15on-1.52.jar" />
 	<classpathentry kind="lib" path="ext/bcmail-jdk15on-1.52.jar" sourcepath="ext/src/bcmail-jdk15on-1.52.jar" />
 	<classpathentry kind="lib" path="ext/bcpkix-jdk15on-1.52.jar" sourcepath="ext/src/bcpkix-jdk15on-1.52.jar" />

--- a/build.moxie
+++ b/build.moxie
@@ -107,7 +107,7 @@ properties: {
   slf4j.version  : 1.7.12
   wicket.version : 1.4.22
   lucene.version : 5.5.2
-  jgit.version   : 4.1.1.201511131810-r
+  jgit.version   : 4.8.0.201706111038-r
   groovy.version : 2.4.4
   bouncycastle.version : 1.52
   selenium.version : 2.28.0

--- a/gitblit.iml
+++ b/gitblit.iml
@@ -409,35 +409,35 @@
       </library>
     </orderEntry>
     <orderEntry type="module-library">
-      <library name="org.eclipse.jgit-4.1.1.201511131810-r.jar">
+      <library name="org.eclipse.jgit-4.8.0.201706111038-r.jar">
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/ext/org.eclipse.jgit-4.1.1.201511131810-r.jar!/" />
+          <root url="jar://$MODULE_DIR$/ext/org.eclipse.jgit-4.8.0.201706111038-r.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/ext/src/org.eclipse.jgit-4.1.1.201511131810-r.jar!/" />
+          <root url="jar://$MODULE_DIR$/ext/src/org.eclipse.jgit-4.8.0.201706111038-r.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library">
-      <library name="jsch-0.1.53.jar">
+      <library name="jsch-0.1.54.jar">
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/ext/jsch-0.1.53.jar!/" />
+          <root url="jar://$MODULE_DIR$/ext/jsch-0.1.54.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/ext/src/jsch-0.1.53.jar!/" />
+          <root url="jar://$MODULE_DIR$/ext/src/jsch-0.1.54.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library">
-      <library name="JavaEWAH-0.7.9.jar">
+      <library name="JavaEWAH-1.1.6.jar">
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/ext/JavaEWAH-0.7.9.jar!/" />
+          <root url="jar://$MODULE_DIR$/ext/JavaEWAH-1.1.6.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/ext/src/JavaEWAH-0.7.9.jar!/" />
+          <root url="jar://$MODULE_DIR$/ext/src/JavaEWAH-1.1.6.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
@@ -486,24 +486,13 @@
       </library>
     </orderEntry>
     <orderEntry type="module-library">
-      <library name="org.eclipse.jdt.annotation-1.1.0.jar">
+      <library name="org.eclipse.jgit.http.server-4.8.0.201706111038-r.jar">
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/ext/org.eclipse.jdt.annotation-1.1.0.jar!/" />
+          <root url="jar://$MODULE_DIR$/ext/org.eclipse.jgit.http.server-4.8.0.201706111038-r.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/ext/src/org.eclipse.jdt.annotation-1.1.0.jar!/" />
-        </SOURCES>
-      </library>
-    </orderEntry>
-    <orderEntry type="module-library">
-      <library name="org.eclipse.jgit.http.server-4.1.1.201511131810-r.jar">
-        <CLASSES>
-          <root url="jar://$MODULE_DIR$/ext/org.eclipse.jgit.http.server-4.1.1.201511131810-r.jar!/" />
-        </CLASSES>
-        <JAVADOC />
-        <SOURCES>
-          <root url="jar://$MODULE_DIR$/ext/src/org.eclipse.jgit.http.server-4.1.1.201511131810-r.jar!/" />
+          <root url="jar://$MODULE_DIR$/ext/src/org.eclipse.jgit.http.server-4.8.0.201706111038-r.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>


### PR DESCRIPTION
Current release of gitblit is based on version 4.1.1.201511131810-r
which fails to start throwing an UnsupportedCharsetException if a
commit contains an unknown character set encoding (e.g. System).

This new jgit version recovers from the exception.

See changes to class org.eclipse.jgit.util.RawParseUtils,

public static Charset parseEncoding(final byte[] b)