### PR TITLE
Added javax.activation dependency "

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -80,6 +80,7 @@
 	<classpathentry kind="lib" path="ext/pf4j-0.9.0.jar" sourcepath="ext/src/pf4j-0.9.0.jar" />
 	<classpathentry kind="lib" path="ext/tika-core-1.5.jar" sourcepath="ext/src/tika-core-1.5.jar" />
 	<classpathentry kind="lib" path="ext/jsoup-1.7.3.jar" sourcepath="ext/src/jsoup-1.7.3.jar" />
+	<classpathentry kind="lib" path="ext/javax.activation-api-1.2.0.jar" sourcepath="ext/src/javax.activation-api-1.2.0.jar" />
 	<classpathentry kind="lib" path="ext/junit-4.12.jar" sourcepath="ext/src/junit-4.12.jar" />
 	<classpathentry kind="lib" path="ext/hamcrest-core-1.3.jar" sourcepath="ext/src/hamcrest-core-1.3.jar" />
 	<classpathentry kind="lib" path="ext/selenium-java-2.28.0.jar" sourcepath="ext/src/selenium-java-2.28.0.jar" />

--- a/.classpath
+++ b/.classpath
@@ -80,7 +80,7 @@
 	<classpathentry kind="lib" path="ext/pf4j-0.9.0.jar" sourcepath="ext/src/pf4j-0.9.0.jar" />
 	<classpathentry kind="lib" path="ext/tika-core-1.5.jar" sourcepath="ext/src/tika-core-1.5.jar" />
 	<classpathentry kind="lib" path="ext/jsoup-1.7.3.jar" sourcepath="ext/src/jsoup-1.7.3.jar" />
-	<classpathentry kind="lib" path="ext/javax.activation-api-1.2.0.jar" sourcepath="ext/src/javax.activation-api-1.2.0.jar" />
+	<classpathentry kind="lib" path="ext/javax.activation-1.2.0.jar" sourcepath="ext/src/javax.activation-1.2.0.jar" />
 	<classpathentry kind="lib" path="ext/junit-4.12.jar" sourcepath="ext/src/junit-4.12.jar" />
 	<classpathentry kind="lib" path="ext/hamcrest-core-1.3.jar" sourcepath="ext/src/hamcrest-core-1.3.jar" />
 	<classpathentry kind="lib" path="ext/selenium-java-2.28.0.jar" sourcepath="ext/src/selenium-java-2.28.0.jar" />

--- a/build.moxie
+++ b/build.moxie
@@ -181,7 +181,7 @@ dependencies:
 - compile 'ro.fortsoft.pf4j:pf4j:0.9.0' :war
 - compile 'org.apache.tika:tika-core:1.5' :war
 - compile 'org.jsoup:jsoup:1.7.3' :war
-- compile 'javax.activation:javax.activation-api:1.2.0'
+- compile 'com.sun.activation:javax.activation:1.2.0'
 - test 'junit:junit:4.12'
 # Dependencies for Selenium web page testing
 - test 'org.seleniumhq.selenium:selenium-java:${selenium.version}' @jar

--- a/build.moxie
+++ b/build.moxie
@@ -181,6 +181,7 @@ dependencies:
 - compile 'ro.fortsoft.pf4j:pf4j:0.9.0' :war
 - compile 'org.apache.tika:tika-core:1.5' :war
 - compile 'org.jsoup:jsoup:1.7.3' :war
+- compile 'javax.activation:javax.activation-api:1.2.0'
 - test 'junit:junit:4.12'
 # Dependencies for Selenium web page testing
 - test 'org.seleniumhq.selenium:selenium-java:${selenium.version}' @jar

--- a/gitblit.iml
+++ b/gitblit.iml
@@ -825,13 +825,13 @@
       </library>
     </orderEntry>
     <orderEntry type="module-library">
-      <library name="javax.activation-api-1.2.0.jar">
+      <library name="javax.activation-1.2.0.jar">
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/ext/javax.activation-api-1.2.0.jar!/" />
+          <root url="jar://$MODULE_DIR$/ext/javax.activation-1.2.0.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/ext/src/javax.activation-api-1.2.0.jar!/" />
+          <root url="jar://$MODULE_DIR$/ext/src/javax.activation-1.2.0.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>

--- a/gitblit.iml
+++ b/gitblit.iml
@@ -824,6 +824,17 @@
         </SOURCES>
       </library>
     </orderEntry>
+    <orderEntry type="module-library">
+      <library name="javax.activation-api-1.2.0.jar">
+        <CLASSES>
+          <root url="jar://$MODULE_DIR$/ext/javax.activation-api-1.2.0.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES>
+          <root url="jar://$MODULE_DIR$/ext/src/javax.activation-api-1.2.0.jar!/" />
+        </SOURCES>
+      </library>
+    </orderEntry>
     <orderEntry type="module-library" scope="TEST">
       <library name="junit-4.12.jar">
         <CLASSES>


### PR DESCRIPTION
thanks to this dependency, one can start gitblit with java 9 without using deprecated internal module --add-modules java.activation

addresses #1262 