### PR TITLE
Better compatibility with SSH clients (eg, Jenkins/BlueOcean) and add EdDSA key support by upgrading sshd

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -42,7 +42,7 @@
 	<classpathentry kind="lib" path="ext/tracwiki-core-1.4.jar" sourcepath="ext/src/tracwiki-core-1.4.jar" />
 	<classpathentry kind="lib" path="ext/mediawiki-core-1.4.jar" sourcepath="ext/src/mediawiki-core-1.4.jar" />
 	<classpathentry kind="lib" path="ext/confluence-core-1.4.jar" sourcepath="ext/src/confluence-core-1.4.jar" />
-	<classpathentry kind="lib" path="ext/org.eclipse.jgit-4.1.1.201511131810-r.jar" sourcepath="ext/src/org.eclipse.jgit-4.1.1.201511131810-r.jar" />
+	<classpathentry kind="lib" path="ext/org.eclipse.jgit-4.1.2.201602141800-r.jar" sourcepath="ext/src/org.eclipse.jgit-4.1.2.201602141800-r.jar" />
 	<classpathentry kind="lib" path="ext/jsch-0.1.53.jar" sourcepath="ext/src/jsch-0.1.53.jar" />
 	<classpathentry kind="lib" path="ext/JavaEWAH-0.7.9.jar" sourcepath="ext/src/JavaEWAH-0.7.9.jar" />
 	<classpathentry kind="lib" path="ext/httpclient-4.3.6.jar" sourcepath="ext/src/httpclient-4.3.6.jar" />
@@ -50,12 +50,13 @@
 	<classpathentry kind="lib" path="ext/commons-logging-1.1.3.jar" sourcepath="ext/src/commons-logging-1.1.3.jar" />
 	<classpathentry kind="lib" path="ext/commons-codec-1.7.jar" sourcepath="ext/src/commons-codec-1.7.jar" />
 	<classpathentry kind="lib" path="ext/org.eclipse.jdt.annotation-1.1.0.jar" sourcepath="ext/src/org.eclipse.jdt.annotation-1.1.0.jar" />
-	<classpathentry kind="lib" path="ext/org.eclipse.jgit.http.server-4.1.1.201511131810-r.jar" sourcepath="ext/src/org.eclipse.jgit.http.server-4.1.1.201511131810-r.jar" />
+	<classpathentry kind="lib" path="ext/org.eclipse.jgit.http.server-4.1.2.201602141800-r.jar" sourcepath="ext/src/org.eclipse.jgit.http.server-4.1.2.201602141800-r.jar" />
 	<classpathentry kind="lib" path="ext/bcprov-jdk15on-1.52.jar" sourcepath="ext/src/bcprov-jdk15on-1.52.jar" />
 	<classpathentry kind="lib" path="ext/bcmail-jdk15on-1.52.jar" sourcepath="ext/src/bcmail-jdk15on-1.52.jar" />
 	<classpathentry kind="lib" path="ext/bcpkix-jdk15on-1.52.jar" sourcepath="ext/src/bcpkix-jdk15on-1.52.jar" />
-	<classpathentry kind="lib" path="ext/sshd-core-1.0.0.jar" sourcepath="ext/src/sshd-core-1.0.0.jar" />
-	<classpathentry kind="lib" path="ext/mina-core-2.0.9.jar" sourcepath="ext/src/mina-core-2.0.9.jar" />
+	<classpathentry kind="lib" path="ext/eddsa-0.2.0.jar" sourcepath="ext/src/eddsa-0.2.0.jar" />
+	<classpathentry kind="lib" path="ext/sshd-core-1.6.0.jar" sourcepath="ext/src/sshd-core-1.6.0.jar" />
+	<classpathentry kind="lib" path="ext/mina-core-2.0.16.jar" sourcepath="ext/src/mina-core-2.0.16.jar" />
 	<classpathentry kind="lib" path="ext/rome-0.9.jar" sourcepath="ext/src/rome-0.9.jar" />
 	<classpathentry kind="lib" path="ext/jdom-1.0.jar" sourcepath="ext/src/jdom-1.0.jar" />
 	<classpathentry kind="lib" path="ext/gson-2.3.1.jar" sourcepath="ext/src/gson-2.3.1.jar" />

--- a/build.moxie
+++ b/build.moxie
@@ -107,12 +107,12 @@ properties: {
   slf4j.version  : 1.7.12
   wicket.version : 1.4.22
   lucene.version : 5.5.2
-  jgit.version   : 4.1.1.201511131810-r
+  jgit.version   : 4.1.2.201602141800-r
   groovy.version : 2.4.4
   bouncycastle.version : 1.52
   selenium.version : 2.28.0
   wikitext.version : 1.4
-  sshd.version: 1.2.0
+  sshd.version: 1.6.0
   mina.version: 2.0.16
   guice.version : 4.0
   # Gitblit maintains a fork of guice-servlet
@@ -161,6 +161,7 @@ dependencies:
 - compile 'org.bouncycastle:bcprov-jdk15on:${bouncycastle.version}' :war
 - compile 'org.bouncycastle:bcmail-jdk15on:${bouncycastle.version}' :war
 - compile 'org.bouncycastle:bcpkix-jdk15on:${bouncycastle.version}' :war
+- compile 'net.i2p.crypto:eddsa:0.2.0' :war !org.easymock
 - compile 'org.apache.sshd:sshd-core:${sshd.version}' :war !org.easymock
 - compile 'org.apache.mina:mina-core:${mina.version}' :war !org.easymock
 - compile 'rome:rome:0.9' :war :manager :api

--- a/build.moxie
+++ b/build.moxie
@@ -112,8 +112,8 @@ properties: {
   bouncycastle.version : 1.52
   selenium.version : 2.28.0
   wikitext.version : 1.4
-  sshd.version: 1.0.0
-  mina.version: 2.0.9
+  sshd.version: 1.2.0
+  mina.version: 2.0.16
   guice.version : 4.0
   # Gitblit maintains a fork of guice-servlet
   guice-servlet.version : 4.0-gb2

--- a/src/main/java/com/gitblit/transport/ssh/FileKeyPairProvider.java
+++ b/src/main/java/com/gitblit/transport/ssh/FileKeyPairProvider.java
@@ -26,7 +26,7 @@ import java.util.Iterator;
 import java.util.NoSuchElementException;
 
 import org.apache.sshd.common.keyprovider.AbstractKeyPairProvider;
-import org.apache.sshd.common.util.SecurityUtils;
+import org.apache.sshd.common.util.security.SecurityUtils;
 import org.bouncycastle.openssl.PEMDecryptorProvider;
 import org.bouncycastle.openssl.PEMEncryptedKeyPair;
 import org.bouncycastle.openssl.PEMKeyPair;

--- a/src/main/java/com/gitblit/transport/ssh/LdapKeyManager.java
+++ b/src/main/java/com/gitblit/transport/ssh/LdapKeyManager.java
@@ -26,9 +26,9 @@ import java.util.TreeMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.apache.sshd.common.config.keys.AuthorizedKeyEntry;
 import org.apache.sshd.common.config.keys.KeyUtils;
 import org.apache.sshd.common.util.GenericUtils;
-import org.apache.sshd.server.config.keys.AuthorizedKeyEntry;
 
 import com.gitblit.IStoredSettings;
 import com.gitblit.Keys;
@@ -212,7 +212,7 @@ public class LdapKeyManager extends IPublicKeyManager {
 					List<SshKey> keyList = new ArrayList<>(authorizedKeys.size());
 					for (GbAuthorizedKeyEntry keyEntry : authorizedKeys) {
 						try {
-							SshKey key = new SshKey(keyEntry.resolvePublicKey());
+							SshKey key = new SshKey(keyEntry.resolvePublicKey(null));
 							key.setComment(keyEntry.getComment());
 							setKeyPermissions(key, keyEntry);
 							keyList.add(key);

--- a/src/main/java/com/gitblit/transport/ssh/NonForwardingFilter.java
+++ b/src/main/java/com/gitblit/transport/ssh/NonForwardingFilter.java
@@ -21,23 +21,23 @@ import org.apache.sshd.server.forward.ForwardingFilter;
 
 public class NonForwardingFilter implements ForwardingFilter {
 
-	@Override
-	public boolean canConnect(Type type, SshdSocketAddress address, Session session) {
-		return false;
-	}
+    @Override
+    public boolean canConnect(Type type, SshdSocketAddress address, Session session) {
+        return false;
+    }
 
-	@Override
-	public boolean canForwardAgent(Session session) {
-		return false;
-	}
+    @Override
+    public boolean canForwardAgent(Session session, String requestType) {
+        return false;
+    }
 
-	@Override
-	public boolean canForwardX11(Session session) {
-		return false;
-	}
+    @Override
+    public boolean canForwardX11(Session session, String requestType) {
+        return false;
+    }
 
-	@Override
-	public boolean canListen(SshdSocketAddress address, Session session) {
-		return false;
-	}
+    @Override
+    public boolean canListen(SshdSocketAddress address, Session session) {
+        return false;
+    }
 }

--- a/src/main/java/com/gitblit/transport/ssh/NonForwardingFilter.java
+++ b/src/main/java/com/gitblit/transport/ssh/NonForwardingFilter.java
@@ -15,8 +15,8 @@
  */
 package com.gitblit.transport.ssh;
 
-import org.apache.sshd.common.SshdSocketAddress;
 import org.apache.sshd.common.session.Session;
+import org.apache.sshd.common.util.net.SshdSocketAddress;
 import org.apache.sshd.server.forward.ForwardingFilter;
 
 public class NonForwardingFilter implements ForwardingFilter {

--- a/src/main/java/com/gitblit/transport/ssh/SshDaemon.java
+++ b/src/main/java/com/gitblit/transport/ssh/SshDaemon.java
@@ -29,7 +29,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.sshd.common.io.IoServiceFactoryFactory;
 import org.apache.sshd.common.io.mina.MinaServiceFactoryFactory;
 import org.apache.sshd.common.io.nio2.Nio2ServiceFactoryFactory;
-import org.apache.sshd.common.util.SecurityUtils;
+import org.apache.sshd.common.util.security.SecurityUtils;
+import org.apache.sshd.common.util.security.bouncycastle.BouncyCastleSecurityProviderRegistrar;
+import org.apache.sshd.common.util.security.eddsa.EdDSASecurityProviderRegistrar;
 import org.apache.sshd.server.SshServer;
 import org.apache.sshd.server.auth.pubkey.CachingPublicKeyAuthenticator;
 import org.bouncycastle.openssl.PEMWriter;
@@ -92,9 +94,11 @@ public class SshDaemon {
 		IStoredSettings settings = gitblit.getSettings();
 
 		// Ensure that Bouncy Castle is our JCE provider
-		SecurityUtils.setRegisterBouncyCastle(true);
+		SecurityUtils.registerSecurityProvider(new BouncyCastleSecurityProviderRegistrar());
+		// Add support for ED25519_SHA512
+		SecurityUtils.registerSecurityProvider(new EdDSASecurityProviderRegistrar());
 		if (SecurityUtils.isBouncyCastleRegistered()) {
-			log.debug("BouncyCastle is registered as a JCE provider");
+			log.info("BouncyCastle is registered as a JCE provider");
 		}
 
 		// Generate host RSA and DSA keypairs and create the host keypair provider

--- a/src/main/java/com/gitblit/transport/ssh/SshDaemon.java
+++ b/src/main/java/com/gitblit/transport/ssh/SshDaemon.java
@@ -31,7 +31,7 @@ import org.apache.sshd.common.io.mina.MinaServiceFactoryFactory;
 import org.apache.sshd.common.io.nio2.Nio2ServiceFactoryFactory;
 import org.apache.sshd.common.util.SecurityUtils;
 import org.apache.sshd.server.SshServer;
-import org.apache.sshd.server.auth.CachingPublicKeyAuthenticator;
+import org.apache.sshd.server.auth.pubkey.CachingPublicKeyAuthenticator;
 import org.bouncycastle.openssl.PEMWriter;
 import org.eclipse.jgit.internal.JGitText;
 import org.slf4j.Logger;
@@ -158,7 +158,7 @@ public class SshDaemon {
 			log.info("SSH: adding GSSAPI authentication method.");
 		}
 
-		sshd.setSessionFactory(new SshServerSessionFactory());
+		sshd.setSessionFactory(new SshServerSessionFactory(sshd));
 		sshd.setFileSystemFactory(new DisabledFilesystemFactory());
 		sshd.setTcpipForwardingFilter(new NonForwardingFilter());
 		sshd.setCommandFactory(new SshCommandFactory(gitblit, workQueue));

--- a/src/main/java/com/gitblit/transport/ssh/SshDaemonClient.java
+++ b/src/main/java/com/gitblit/transport/ssh/SshDaemonClient.java
@@ -17,9 +17,9 @@ package com.gitblit.transport.ssh;
 
 import java.net.SocketAddress;
 
-import org.apache.sshd.common.session.Session.AttributeKey;
 
 import com.gitblit.models.UserModel;
+import org.apache.sshd.common.AttributeStore;
 
 /**
  *
@@ -27,7 +27,7 @@ import com.gitblit.models.UserModel;
  *
  */
 public class SshDaemonClient {
-	public static final AttributeKey<SshDaemonClient> KEY = new AttributeKey<SshDaemonClient>();
+	public static final AttributeStore.AttributeKey<SshDaemonClient> KEY = new AttributeStore.AttributeKey<SshDaemonClient>();
 
 	private final SocketAddress remoteAddress;
 

--- a/src/main/java/com/gitblit/transport/ssh/SshServerSessionFactory.java
+++ b/src/main/java/com/gitblit/transport/ssh/SshServerSessionFactory.java
@@ -22,7 +22,9 @@ import org.apache.sshd.common.future.CloseFuture;
 import org.apache.sshd.common.future.SshFutureListener;
 import org.apache.sshd.common.io.IoSession;
 import org.apache.sshd.common.io.mina.MinaSession;
-import org.apache.sshd.common.session.AbstractSession;
+import org.apache.sshd.common.session.helpers.AbstractSession;
+import org.apache.sshd.server.ServerFactoryManager;
+import org.apache.sshd.server.session.ServerSessionImpl;
 import org.apache.sshd.server.session.SessionFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,11 +38,12 @@ public class SshServerSessionFactory extends SessionFactory {
 
 	private final Logger log = LoggerFactory.getLogger(getClass());
 
-	public SshServerSessionFactory() {
+	public SshServerSessionFactory(ServerFactoryManager server) {
+		super(server);
 	}
 
 	@Override
-	protected AbstractSession createSession(final IoSession io) throws Exception {
+	protected ServerSessionImpl createSession(final IoSession io) throws Exception {
 		log.info("creating ssh session from {}", io.getRemoteAddress());
 
 		if (io instanceof MinaSession) {
@@ -66,7 +69,7 @@ public class SshServerSessionFactory extends SessionFactory {
 	}
 
 	@Override
-	protected AbstractSession doCreateSession(IoSession ioSession) throws Exception {
+	protected ServerSessionImpl doCreateSession(IoSession ioSession) throws Exception {
 		return new SshServerSession(getServer(), ioSession);
 	}
 }

--- a/src/main/java/com/gitblit/transport/ssh/WelcomeShell.java
+++ b/src/main/java/com/gitblit/transport/ssh/WelcomeShell.java
@@ -57,6 +57,11 @@ public class WelcomeShell implements Factory<Command> {
 		return new SendMessage(gitblit);
 	}
 
+	@Override
+	public Command get() {
+		return create();
+	}
+
 	private static class SendMessage implements Command, SessionAware {
 
 		private final IPublicKeyManager km;

--- a/src/test/java/com/gitblit/tests/LdapPublicKeyManagerTest.java
+++ b/src/test/java/com/gitblit/tests/LdapPublicKeyManagerTest.java
@@ -28,7 +28,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.sshd.common.util.SecurityUtils;
+import org.apache.sshd.common.util.security.SecurityUtils;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/src/test/java/com/gitblit/tests/SshDaemonTest.java
+++ b/src/test/java/com/gitblit/tests/SshDaemonTest.java
@@ -44,9 +44,9 @@ public class SshDaemonTest extends SshUnitTest {
 	@Test
 	public void testPublicKeyAuthentication() throws Exception {
 		SshClient client = getClient();
-		ClientSession session = client.connect(username, "localhost", GitBlitSuite.sshPort).await().getSession();
+		ClientSession session = client.connect(username, "localhost", GitBlitSuite.sshPort).getSession();
 		session.addPublicKeyIdentity(rwKeyPair);
-		assertTrue(session.auth().await().isSuccess());
+		assertTrue(session.auth().isSuccess());
 	}
 
 	@Test

--- a/src/test/java/com/gitblit/tests/SshUnitTest.java
+++ b/src/test/java/com/gitblit/tests/SshUnitTest.java
@@ -15,20 +15,16 @@
  */
 package com.gitblit.tests;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.OutputStreamWriter;
-import java.io.Writer;
-import java.net.SocketAddress;
-import java.security.KeyPair;
-import java.security.KeyPairGenerator;
-import java.security.PublicKey;
-import java.util.concurrent.atomic.AtomicBoolean;
-
-import org.apache.sshd.client.ServerKeyVerifier;
+import com.gitblit.Constants.AccessPermission;
+import com.gitblit.transport.ssh.IPublicKeyManager;
+import com.gitblit.transport.ssh.MemoryKeyManager;
+import com.gitblit.transport.ssh.SshKey;
 import org.apache.sshd.client.SshClient;
 import org.apache.sshd.client.channel.ClientChannel;
+import org.apache.sshd.client.channel.ClientChannelEvent;
+import org.apache.sshd.client.future.AuthFuture;
+import org.apache.sshd.client.future.ConnectFuture;
+import org.apache.sshd.client.keyverifier.ServerKeyVerifier;
 import org.apache.sshd.client.session.ClientSession;
 import org.apache.sshd.common.util.SecurityUtils;
 import org.junit.After;
@@ -36,106 +32,114 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 
-import com.gitblit.Constants.AccessPermission;
-import com.gitblit.transport.ssh.IPublicKeyManager;
-import com.gitblit.transport.ssh.MemoryKeyManager;
-import com.gitblit.transport.ssh.SshKey;
+import java.io.*;
+import java.net.SocketAddress;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.PublicKey;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Base class for SSH unit tests.
  */
 public abstract class SshUnitTest extends GitblitUnitTest {
 
-	protected static final AtomicBoolean started = new AtomicBoolean(false);
-	protected static KeyPairGenerator generator;
-	protected KeyPair rwKeyPair;
-	protected KeyPair roKeyPair;
-	protected String username = "admin";
-	protected String password = "admin";
+    protected static final AtomicBoolean started = new AtomicBoolean(false);
+    protected static KeyPairGenerator generator;
+    protected KeyPair rwKeyPair;
+    protected KeyPair roKeyPair;
+    protected String username = "admin";
+    protected String password = "admin";
 
-	@BeforeClass
-	public static void startGitblit() throws Exception {
-		generator = SecurityUtils.getKeyPairGenerator("RSA");
-		started.set(GitBlitSuite.startGitblit());
-	}
+    @BeforeClass
+    public static void startGitblit() throws Exception {
+        generator = SecurityUtils.getKeyPairGenerator("RSA");
+        started.set(GitBlitSuite.startGitblit());
+    }
 
-	@AfterClass
-	public static void stopGitblit() throws Exception {
-		if (started.get()) {
-			GitBlitSuite.stopGitblit();
-		}
-	}
+    @AfterClass
+    public static void stopGitblit() throws Exception {
+        if (started.get()) {
+            GitBlitSuite.stopGitblit();
+        }
+    }
 
-	protected MemoryKeyManager getKeyManager() {
-		IPublicKeyManager mgr = gitblit().getPublicKeyManager();
-		if (mgr instanceof MemoryKeyManager) {
-			return (MemoryKeyManager) gitblit().getPublicKeyManager();
-		} else {
-			throw new RuntimeException("unexpected key manager type " + mgr.getClass().getName());
-		}
-	}
+    protected MemoryKeyManager getKeyManager() {
+        IPublicKeyManager mgr = gitblit().getPublicKeyManager();
+        if (mgr instanceof MemoryKeyManager) {
+            return (MemoryKeyManager) gitblit().getPublicKeyManager();
+        } else {
+            throw new RuntimeException("unexpected key manager type " + mgr.getClass().getName());
+        }
+    }
 
-	@Before
-	public void prepare() {
-		rwKeyPair = generator.generateKeyPair();
+    @Before
+    public void prepare() {
+        rwKeyPair = generator.generateKeyPair();
 
-		MemoryKeyManager keyMgr = getKeyManager();
-		keyMgr.addKey(username, new SshKey(rwKeyPair.getPublic()));
+        MemoryKeyManager keyMgr = getKeyManager();
+        keyMgr.addKey(username, new SshKey(rwKeyPair.getPublic()));
 
-		roKeyPair = generator.generateKeyPair();
-		SshKey sshKey = new SshKey(roKeyPair.getPublic());
-		sshKey.setPermission(AccessPermission.CLONE);
-		keyMgr.addKey(username, sshKey);
-	}
+        roKeyPair = generator.generateKeyPair();
+        SshKey sshKey = new SshKey(roKeyPair.getPublic());
+        sshKey.setPermission(AccessPermission.CLONE);
+        keyMgr.addKey(username, sshKey);
+    }
 
-	@After
-	public void tearDown() {
-		MemoryKeyManager keyMgr = getKeyManager();
-		keyMgr.removeAllKeys(username);
-	}
+    @After
+    public void tearDown() {
+        MemoryKeyManager keyMgr = getKeyManager();
+        keyMgr.removeAllKeys(username);
+    }
 
-	protected SshClient getClient() {
-		SshClient client = SshClient.setUpDefaultClient();
-		client.setServerKeyVerifier(new ServerKeyVerifier() {
-			@Override
-			public boolean verifyServerKey(ClientSession sshClientSession, SocketAddress remoteAddress, PublicKey serverKey) {
-				return true;
-			}
-		});
-		client.start();
-		return client;
-	}
+    protected SshClient getClient() {
+        SshClient client = SshClient.setUpDefaultClient();
+        client.setServerKeyVerifier(new ServerKeyVerifier() {
+            @Override
+            public boolean verifyServerKey(ClientSession sshClientSession, SocketAddress remoteAddress, PublicKey serverKey) {
+                return true;
+            }
+        });
+        client.start();
+        return client;
+    }
 
-	protected String testSshCommand(String cmd) throws IOException, InterruptedException {
-		return testSshCommand(cmd, null);
-	}
+    protected String testSshCommand(String cmd) throws IOException, InterruptedException {
+        return testSshCommand(cmd, null);
+    }
 
-	protected String testSshCommand(String cmd, String stdin) throws IOException, InterruptedException {
-		SshClient client = getClient();
-		ClientSession session = client.connect(username, "localhost", GitBlitSuite.sshPort).await().getSession();
-		session.addPublicKeyIdentity(rwKeyPair);
-		assertTrue(session.auth().await().isSuccess());
 
-		ClientChannel channel = session.createChannel(ClientChannel.CHANNEL_EXEC, cmd);
-		ByteArrayOutputStream baos = new ByteArrayOutputStream();
-		if (stdin != null) {
-			Writer w = new OutputStreamWriter(baos);
-			w.write(stdin);
-			w.close();
-		}
-		channel.setIn(new ByteArrayInputStream(baos.toByteArray()));
+    protected String testSshCommand(String cmd, String stdin) throws IOException, InterruptedException {
+        SshClient client = getClient();
+        ConnectFuture futureConnection = client.connect(username, "localhost", GitBlitSuite.sshPort);
+        futureConnection.await();
+        ClientSession session = (ClientSession) futureConnection.getSession();
+        session.addPublicKeyIdentity(rwKeyPair);
+        AuthFuture authFuture = session.auth();
+        authFuture.await();
+        assertTrue(authFuture.isSuccess());
 
-		ByteArrayOutputStream out = new ByteArrayOutputStream();
-		ByteArrayOutputStream err = new ByteArrayOutputStream();
-		channel.setOut(out);
-		channel.setErr(err);
-		channel.open();
+        ClientChannel channel = session.createChannel(ClientChannel.CHANNEL_EXEC, cmd);
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        if (stdin != null) {
+            Writer w = new OutputStreamWriter(baos);
+            w.write(stdin);
+            w.close();
+        }
+        channel.setIn(new ByteArrayInputStream(baos.toByteArray()));
 
-		channel.waitFor(ClientChannel.CLOSED, 0);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+        channel.setOut(out);
+        channel.setErr(err);
+        channel.open();
 
-		String result = out.toString().trim();
-		channel.close(false);
-		client.stop();
-		return result;
-	}
+        channel.waitFor(Collections.singleton(ClientChannelEvent.EOF), 0);
+
+        String result = out.toString().trim();
+        channel.close(false);
+        client.stop();
+        return result;
+    }
 }

--- a/src/test/java/com/gitblit/tests/SshUnitTest.java
+++ b/src/test/java/com/gitblit/tests/SshUnitTest.java
@@ -26,7 +26,7 @@ import org.apache.sshd.client.future.AuthFuture;
 import org.apache.sshd.client.future.ConnectFuture;
 import org.apache.sshd.client.keyverifier.ServerKeyVerifier;
 import org.apache.sshd.client.session.ClientSession;
-import org.apache.sshd.common.util.SecurityUtils;
+import org.apache.sshd.common.util.security.SecurityUtils;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;


### PR DESCRIPTION
Hello! Two commits here.
First one is the minimum needed to make Gitblit work with Jenkins/BlueOcean (resolves the "MAC corrupt" exception). It upgrades sshd to 1.2.0 with no further changes.
Second one upgrades sshd to 1.6.0, and adds a dependency on eddsa, and adds code to register this provider, which in fact (tested) adds support for my new ED25519 ssh key. It also upgrades JGit to a newer point release which is supposed to fix bugs only.
I'm running two production instances of Gitblit with these patches, and finally enjoying Gitblit + Jenkins/Blueocean pipelines.