### PR TITLE
Null-safe compare for ticket milestones without due date

### DIFF
--- a/src/main/java/com/gitblit/wicket/pages/TicketsPage.java
+++ b/src/main/java/com/gitblit/wicket/pages/TicketsPage.java
@@ -521,14 +521,26 @@ public class TicketsPage extends RepositoryPage {
 		Collections.sort(openMilestones, new Comparator<TicketMilestone>() {
 			@Override
 			public int compare(TicketMilestone o1, TicketMilestone o2) {
-				return o2.due.compareTo(o1.due);
+				if (o1.due == null) {
+					return (o2.due == null) ? 0 : 1;
+				} else if (o2.due == null) {
+					return -1;
+				} else {
+					return o1.due.compareTo(o2.due);
+				}
 			}
 		});
 
 		Collections.sort(closedMilestones, new Comparator<TicketMilestone>() {
 			@Override
 			public int compare(TicketMilestone o1, TicketMilestone o2) {
-				return o2.due.compareTo(o1.due);
+				if (o1.due == null) {
+					return (o2.due == null) ? 0 : 1;
+				} else if (o2.due == null) {
+					return -1;
+				} else {
+					return o1.due.compareTo(o2.due);
+				}
 			}
 		});
 


### PR DESCRIPTION
When using Gitblit's Ticket system it is possible to create milestones without a due date. Doing so can result in a NullPointerException when (re)loading the tickets page, due to the not null-save TicketsMilestone comparator.

This pull request makes the comparator null-safe and orders milestones without a due date last.