### PR TITLE
Update dependencies MINA to 2.0.21 and SSHD to 1.2.0

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -13,8 +13,8 @@
 	<classpathentry kind="lib" path="ext/guice-servlet-4.0-gb2.jar" sourcepath="ext/src/guice-servlet-4.0-gb2.jar" />
 	<classpathentry kind="lib" path="ext/annotations-12.0.jar" sourcepath="ext/src/annotations-12.0.jar" />
 	<classpathentry kind="lib" path="ext/log4j-1.2.17.jar" sourcepath="ext/src/log4j-1.2.17.jar" />
-	<classpathentry kind="lib" path="ext/slf4j-api-1.7.12.jar" sourcepath="ext/src/slf4j-api-1.7.12.jar" />
-	<classpathentry kind="lib" path="ext/slf4j-log4j12-1.7.12.jar" sourcepath="ext/src/slf4j-log4j12-1.7.12.jar" />
+	<classpathentry kind="lib" path="ext/slf4j-api-1.7.29.jar" sourcepath="ext/src/slf4j-api-1.7.29.jar" />
+	<classpathentry kind="lib" path="ext/slf4j-log4j12-1.7.29.jar" sourcepath="ext/src/slf4j-log4j12-1.7.29.jar" />
 	<classpathentry kind="lib" path="ext/javax.mail-1.5.1.jar" sourcepath="ext/src/javax.mail-1.5.1.jar" />
 	<classpathentry kind="lib" path="ext/javax.servlet-api-3.1.0.jar" sourcepath="ext/src/javax.servlet-api-3.1.0.jar" />
 	<classpathentry kind="lib" path="ext/jetty-all-9.2.13.v20150730.jar" sourcepath="ext/src/jetty-all-9.2.13.v20150730.jar" />

--- a/.classpath
+++ b/.classpath
@@ -55,7 +55,7 @@
 	<classpathentry kind="lib" path="ext/bcmail-jdk15on-1.57.jar" sourcepath="ext/src/bcmail-jdk15on-1.57.jar" />
 	<classpathentry kind="lib" path="ext/bcpkix-jdk15on-1.57.jar" sourcepath="ext/src/bcpkix-jdk15on-1.57.jar" />
 	<classpathentry kind="lib" path="ext/sshd-core-1.0.0.jar" sourcepath="ext/src/sshd-core-1.0.0.jar" />
-	<classpathentry kind="lib" path="ext/mina-core-2.0.9.jar" sourcepath="ext/src/mina-core-2.0.9.jar" />
+	<classpathentry kind="lib" path="ext/mina-core-2.0.21.jar" sourcepath="ext/src/mina-core-2.0.21.jar" />
 	<classpathentry kind="lib" path="ext/rome-0.9.jar" sourcepath="ext/src/rome-0.9.jar" />
 	<classpathentry kind="lib" path="ext/jdom-1.0.jar" sourcepath="ext/src/jdom-1.0.jar" />
 	<classpathentry kind="lib" path="ext/gson-2.3.1.jar" sourcepath="ext/src/gson-2.3.1.jar" />

--- a/.classpath
+++ b/.classpath
@@ -54,7 +54,7 @@
 	<classpathentry kind="lib" path="ext/bcprov-jdk15on-1.57.jar" sourcepath="ext/src/bcprov-jdk15on-1.57.jar" />
 	<classpathentry kind="lib" path="ext/bcmail-jdk15on-1.57.jar" sourcepath="ext/src/bcmail-jdk15on-1.57.jar" />
 	<classpathentry kind="lib" path="ext/bcpkix-jdk15on-1.57.jar" sourcepath="ext/src/bcpkix-jdk15on-1.57.jar" />
-	<classpathentry kind="lib" path="ext/sshd-core-1.1.0.jar" sourcepath="ext/src/sshd-core-1.1.0.jar" />
+	<classpathentry kind="lib" path="ext/sshd-core-1.2.0.jar" sourcepath="ext/src/sshd-core-1.2.0.jar" />
 	<classpathentry kind="lib" path="ext/mina-core-2.0.21.jar" sourcepath="ext/src/mina-core-2.0.21.jar" />
 	<classpathentry kind="lib" path="ext/rome-0.9.jar" sourcepath="ext/src/rome-0.9.jar" />
 	<classpathentry kind="lib" path="ext/jdom-1.0.jar" sourcepath="ext/src/jdom-1.0.jar" />

--- a/.classpath
+++ b/.classpath
@@ -54,7 +54,7 @@
 	<classpathentry kind="lib" path="ext/bcprov-jdk15on-1.57.jar" sourcepath="ext/src/bcprov-jdk15on-1.57.jar" />
 	<classpathentry kind="lib" path="ext/bcmail-jdk15on-1.57.jar" sourcepath="ext/src/bcmail-jdk15on-1.57.jar" />
 	<classpathentry kind="lib" path="ext/bcpkix-jdk15on-1.57.jar" sourcepath="ext/src/bcpkix-jdk15on-1.57.jar" />
-	<classpathentry kind="lib" path="ext/sshd-core-1.0.0.jar" sourcepath="ext/src/sshd-core-1.0.0.jar" />
+	<classpathentry kind="lib" path="ext/sshd-core-1.1.0.jar" sourcepath="ext/src/sshd-core-1.1.0.jar" />
 	<classpathentry kind="lib" path="ext/mina-core-2.0.21.jar" sourcepath="ext/src/mina-core-2.0.21.jar" />
 	<classpathentry kind="lib" path="ext/rome-0.9.jar" sourcepath="ext/src/rome-0.9.jar" />
 	<classpathentry kind="lib" path="ext/jdom-1.0.jar" sourcepath="ext/src/jdom-1.0.jar" />

--- a/build.moxie
+++ b/build.moxie
@@ -112,7 +112,7 @@ properties: {
   bouncycastle.version : 1.57
   selenium.version : 2.28.0
   wikitext.version : 1.4
-  sshd.version: 1.0.0
+  sshd.version: 1.1.0
   mina.version: 2.0.21
   guice.version : 4.0
   # Gitblit maintains a fork of guice-servlet

--- a/build.moxie
+++ b/build.moxie
@@ -113,7 +113,7 @@ properties: {
   selenium.version : 2.28.0
   wikitext.version : 1.4
   sshd.version: 1.0.0
-  mina.version: 2.0.9
+  mina.version: 2.0.21
   guice.version : 4.0
   # Gitblit maintains a fork of guice-servlet
   guice-servlet.version : 4.0-gb2

--- a/build.moxie
+++ b/build.moxie
@@ -112,7 +112,7 @@ properties: {
   bouncycastle.version : 1.57
   selenium.version : 2.28.0
   wikitext.version : 1.4
-  sshd.version: 1.1.0
+  sshd.version: 1.2.0
   mina.version: 2.0.21
   guice.version : 4.0
   # Gitblit maintains a fork of guice-servlet

--- a/build.moxie
+++ b/build.moxie
@@ -104,7 +104,7 @@ repositories: central, eclipse-snapshots, eclipse, gitblit
 # Convenience properties for dependencies
 properties: {
   jetty.version  : 9.2.13.v20150730
-  slf4j.version  : 1.7.12
+  slf4j.version  : 1.7.29
   wicket.version : 1.4.22
   lucene.version : 5.5.2
   jgit.version   : 4.1.1.201511131810-r

--- a/gitblit.iml
+++ b/gitblit.iml
@@ -552,13 +552,13 @@
       </library>
     </orderEntry>
     <orderEntry type="module-library">
-      <library name="mina-core-2.0.9.jar">
+      <library name="mina-core-2.0.21.jar">
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/ext/mina-core-2.0.9.jar!/" />
+          <root url="jar://$MODULE_DIR$/ext/mina-core-2.0.21.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/ext/src/mina-core-2.0.9.jar!/" />
+          <root url="jar://$MODULE_DIR$/ext/src/mina-core-2.0.21.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>

--- a/gitblit.iml
+++ b/gitblit.iml
@@ -541,13 +541,13 @@
       </library>
     </orderEntry>
     <orderEntry type="module-library">
-      <library name="sshd-core-1.0.0.jar">
+      <library name="sshd-core-1.1.0.jar">
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/ext/sshd-core-1.0.0.jar!/" />
+          <root url="jar://$MODULE_DIR$/ext/sshd-core-1.1.0.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/ext/src/sshd-core-1.0.0.jar!/" />
+          <root url="jar://$MODULE_DIR$/ext/src/sshd-core-1.1.0.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>

--- a/gitblit.iml
+++ b/gitblit.iml
@@ -92,24 +92,24 @@
       </library>
     </orderEntry>
     <orderEntry type="module-library">
-      <library name="slf4j-api-1.7.12.jar">
+      <library name="slf4j-api-1.7.29.jar">
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/ext/slf4j-api-1.7.12.jar!/" />
+          <root url="jar://$MODULE_DIR$/ext/slf4j-api-1.7.29.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/ext/src/slf4j-api-1.7.12.jar!/" />
+          <root url="jar://$MODULE_DIR$/ext/src/slf4j-api-1.7.29.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library">
-      <library name="slf4j-log4j12-1.7.12.jar">
+      <library name="slf4j-log4j12-1.7.29.jar">
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/ext/slf4j-log4j12-1.7.12.jar!/" />
+          <root url="jar://$MODULE_DIR$/ext/slf4j-log4j12-1.7.29.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/ext/src/slf4j-log4j12-1.7.12.jar!/" />
+          <root url="jar://$MODULE_DIR$/ext/src/slf4j-log4j12-1.7.29.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>

--- a/gitblit.iml
+++ b/gitblit.iml
@@ -541,13 +541,13 @@
       </library>
     </orderEntry>
     <orderEntry type="module-library">
-      <library name="sshd-core-1.1.0.jar">
+      <library name="sshd-core-1.2.0.jar">
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/ext/sshd-core-1.1.0.jar!/" />
+          <root url="jar://$MODULE_DIR$/ext/sshd-core-1.2.0.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/ext/src/sshd-core-1.1.0.jar!/" />
+          <root url="jar://$MODULE_DIR$/ext/src/sshd-core-1.2.0.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>

--- a/src/main/java/com/gitblit/transport/ssh/LdapKeyManager.java
+++ b/src/main/java/com/gitblit/transport/ssh/LdapKeyManager.java
@@ -26,9 +26,9 @@ import java.util.TreeMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.apache.sshd.common.config.keys.AuthorizedKeyEntry;
 import org.apache.sshd.common.config.keys.KeyUtils;
 import org.apache.sshd.common.util.GenericUtils;
-import org.apache.sshd.server.config.keys.AuthorizedKeyEntry;
 
 import com.gitblit.IStoredSettings;
 import com.gitblit.Keys;

--- a/src/main/java/com/gitblit/transport/ssh/LdapKeyManager.java
+++ b/src/main/java/com/gitblit/transport/ssh/LdapKeyManager.java
@@ -212,7 +212,7 @@ public class LdapKeyManager extends IPublicKeyManager {
 					List<SshKey> keyList = new ArrayList<>(authorizedKeys.size());
 					for (GbAuthorizedKeyEntry keyEntry : authorizedKeys) {
 						try {
-							SshKey key = new SshKey(keyEntry.resolvePublicKey());
+							SshKey key = new SshKey(keyEntry.resolvePublicKey(null));
 							key.setComment(keyEntry.getComment());
 							setKeyPermissions(key, keyEntry);
 							keyList.add(key);

--- a/src/main/java/com/gitblit/transport/ssh/NonForwardingFilter.java
+++ b/src/main/java/com/gitblit/transport/ssh/NonForwardingFilter.java
@@ -15,8 +15,8 @@
  */
 package com.gitblit.transport.ssh;
 
-import org.apache.sshd.common.SshdSocketAddress;
 import org.apache.sshd.common.session.Session;
+import org.apache.sshd.common.util.net.SshdSocketAddress;
 import org.apache.sshd.server.forward.ForwardingFilter;
 
 public class NonForwardingFilter implements ForwardingFilter {

--- a/src/main/java/com/gitblit/transport/ssh/SshDaemon.java
+++ b/src/main/java/com/gitblit/transport/ssh/SshDaemon.java
@@ -31,7 +31,7 @@ import org.apache.sshd.common.io.mina.MinaServiceFactoryFactory;
 import org.apache.sshd.common.io.nio2.Nio2ServiceFactoryFactory;
 import org.apache.sshd.common.util.SecurityUtils;
 import org.apache.sshd.server.SshServer;
-import org.apache.sshd.server.auth.CachingPublicKeyAuthenticator;
+import org.apache.sshd.server.auth.pubkey.CachingPublicKeyAuthenticator;
 import org.bouncycastle.openssl.PEMWriter;
 import org.eclipse.jgit.internal.JGitText;
 import org.slf4j.Logger;
@@ -158,7 +158,7 @@ public class SshDaemon {
 			log.info("SSH: adding GSSAPI authentication method.");
 		}
 
-		sshd.setSessionFactory(new SshServerSessionFactory());
+		sshd.setSessionFactory(new SshServerSessionFactory(sshd));
 		sshd.setFileSystemFactory(new DisabledFilesystemFactory());
 		sshd.setTcpipForwardingFilter(new NonForwardingFilter());
 		sshd.setCommandFactory(new SshCommandFactory(gitblit, workQueue));

--- a/src/main/java/com/gitblit/transport/ssh/SshDaemonClient.java
+++ b/src/main/java/com/gitblit/transport/ssh/SshDaemonClient.java
@@ -17,7 +17,7 @@ package com.gitblit.transport.ssh;
 
 import java.net.SocketAddress;
 
-import org.apache.sshd.common.session.Session.AttributeKey;
+import org.apache.sshd.common.AttributeStore.AttributeKey;
 
 import com.gitblit.models.UserModel;
 

--- a/src/main/java/com/gitblit/transport/ssh/SshServerSessionFactory.java
+++ b/src/main/java/com/gitblit/transport/ssh/SshServerSessionFactory.java
@@ -22,7 +22,8 @@ import org.apache.sshd.common.future.CloseFuture;
 import org.apache.sshd.common.future.SshFutureListener;
 import org.apache.sshd.common.io.IoSession;
 import org.apache.sshd.common.io.mina.MinaSession;
-import org.apache.sshd.common.session.AbstractSession;
+import org.apache.sshd.server.ServerFactoryManager;
+import org.apache.sshd.server.session.ServerSessionImpl;
 import org.apache.sshd.server.session.SessionFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,11 +37,12 @@ public class SshServerSessionFactory extends SessionFactory {
 
 	private final Logger log = LoggerFactory.getLogger(getClass());
 
-	public SshServerSessionFactory() {
+	public SshServerSessionFactory(ServerFactoryManager server) {
+		super(server);
 	}
 
 	@Override
-	protected AbstractSession createSession(final IoSession io) throws Exception {
+	protected ServerSessionImpl createSession(final IoSession io) throws Exception {
 		log.info("creating ssh session from {}", io.getRemoteAddress());
 
 		if (io instanceof MinaSession) {
@@ -66,7 +68,7 @@ public class SshServerSessionFactory extends SessionFactory {
 	}
 
 	@Override
-	protected AbstractSession doCreateSession(IoSession ioSession) throws Exception {
+	protected ServerSessionImpl doCreateSession(IoSession ioSession) throws Exception {
 		return new SshServerSession(getServer(), ioSession);
 	}
 }

--- a/src/test/java/com/gitblit/tests/SshDaemonTest.java
+++ b/src/test/java/com/gitblit/tests/SshDaemonTest.java
@@ -44,9 +44,9 @@ public class SshDaemonTest extends SshUnitTest {
 	@Test
 	public void testPublicKeyAuthentication() throws Exception {
 		SshClient client = getClient();
-		ClientSession session = client.connect(username, "localhost", GitBlitSuite.sshPort).await().getSession();
+		ClientSession session = client.connect(username, "localhost", GitBlitSuite.sshPort).verify().getSession();
 		session.addPublicKeyIdentity(rwKeyPair);
-		assertTrue(session.auth().await().isSuccess());
+		assertTrue(session.auth().await());
 	}
 
 	@Test
@@ -64,6 +64,7 @@ public class SshDaemonTest extends SshUnitTest {
 
 		// set clone restriction
 		RepositoryModel model = repositories().getRepositoryModel("ticgit.git");
+		assertNotNull("Could not get repository modle for ticgit.git", model);
 		model.accessRestriction = AccessRestrictionType.CLONE;
 		model.authorizationControl = AuthorizationControl.NAMED;
 		repositories().updateRepositoryModel(model.name, model, false);


### PR DESCRIPTION
Update SSHD to fix an issue with hmac-sha2-512. This resolves problems with clients that prefer SHA-512 over SHA-256.

This also updates the dependency on SLF4J to the latest version, as the updated dependency on MINA did also bring in higher SLF4J versions.

This PR includes the changes from PR #1216 and one commit from PR #1272. The SSHD version is kept at 1.2.0 to keep compatibility with Java 7.

Closes #1216 as merged.
Fixes #1254 
Hopefully resolves #1282 
