### PR TITLE
:bug: 1092 fix NPE on clone.bundle

### DIFF
--- a/src/main/java/com/gitblit/servlet/AccessRestrictionFilter.java
+++ b/src/main/java/com/gitblit/servlet/AccessRestrictionFilter.java
@@ -167,6 +167,7 @@ public abstract class AccessRestrictionFilter extends AuthenticationFilter {
 		String fullUrl = getFullUrl(httpRequest);
 		String repository = extractRepositoryName(fullUrl);
 		if (StringUtils.isEmpty(repository)) {
+			logger.info("ARF: Rejecting request, empty repository name in URL {}", fullUrl);
 			httpResponse.setStatus(HttpServletResponse.SC_BAD_REQUEST);
 			return;
 		}
@@ -180,6 +181,12 @@ public abstract class AccessRestrictionFilter extends AuthenticationFilter {
 		// Determine if the request URL is restricted
 		String fullSuffix = fullUrl.substring(repository.length());
 		String urlRequestType = getUrlRequestAction(fullSuffix);
+
+		if (StringUtils.isEmpty(urlRequestType)) {
+			logger.info("ARF: Rejecting request for {}, no supported action found in URL {}", repository, fullSuffix);
+			httpResponse.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+			return;
+		}
 
 		UserModel user = getUser(httpRequest);
 

--- a/src/main/java/com/gitblit/servlet/AccessRestrictionFilter.java
+++ b/src/main/java/com/gitblit/servlet/AccessRestrictionFilter.java
@@ -188,6 +188,15 @@ public abstract class AccessRestrictionFilter extends AuthenticationFilter {
 			return;
 		}
 
+		// TODO: Maybe checking for clone bundle should be done somewhere else? Like other stuff?
+		//       In any way, the access to the constant from here is messed up an needs some cleaning up.
+		if (GitFilter.CLONE_BUNDLE.equalsIgnoreCase(urlRequestType)) {
+			logger.info(MessageFormat.format("ARF: Rejecting request for {0}, clone bundle is not implemented.", repository));
+			httpResponse.sendError(HttpServletResponse.SC_NOT_IMPLEMENTED, "The 'clone.bundle' command is currently not implemented. " +
+					"Please use a normal clone command.");
+			return;
+		}
+
 		UserModel user = getUser(httpRequest);
 
 		// Load the repository model

--- a/src/main/java/com/gitblit/servlet/GitFilter.java
+++ b/src/main/java/com/gitblit/servlet/GitFilter.java
@@ -49,11 +49,13 @@ public class GitFilter extends AccessRestrictionFilter {
 	static final String GIT_RECEIVE_PACK = "/git-receive-pack";
 
 	static final String GIT_UPLOAD_PACK = "/git-upload-pack";
+
+	static final String CLONE_BUNDLE = "/clone.bundle";
 	
 	static final String GIT_LFS = "/info/lfs";
 	
 	static final String[] SUFFIXES = {GIT_RECEIVE_PACK, GIT_UPLOAD_PACK, "/info/refs", "/HEAD",
-			"/objects", GIT_LFS};
+			"/objects", GIT_LFS, CLONE_BUNDLE};
 
 	private IStoredSettings settings;
 
@@ -127,6 +129,8 @@ public class GitFilter extends AccessRestrictionFilter {
 				return GIT_UPLOAD_PACK;
 			} else if (suffix.startsWith(GIT_LFS)) {
 				return GIT_LFS;
+			} else if (suffix.startsWith(CLONE_BUNDLE)) {
+				return CLONE_BUNDLE;
 			} else {
 				return GIT_UPLOAD_PACK;
 			}
@@ -163,7 +167,11 @@ public class GitFilter extends AccessRestrictionFilter {
 		if (GIT_LFS.equals(action)) {
 			return false;
 		}
-		
+		// Action is not implemened.
+		if (CLONE_BUNDLE.equals(action)) {
+			return false;
+		}
+
 		return settings.getBoolean(Keys.git.allowCreateOnPush, true);
 	}
 

--- a/src/test/java/com/gitblit/tests/GitServletTest.java
+++ b/src/test/java/com/gitblit/tests/GitServletTest.java
@@ -978,8 +978,20 @@ public class GitServletTest extends GitblitUnitTest {
 		HttpGet request = new HttpGet(testURL);
 
 		HttpResponse response = client.execute(request);
-
 		assertEquals(400, response.getStatusLine().getStatusCode());
+	}
+
+	@Test
+	public void testInvalidURLCloneBundle() throws IOException {
+		final String testURL = GitBlitSuite.gitServletUrl + "/helloworld.git/clone.bundle";
+
+		HttpClient client = HttpClientBuilder.create().build();
+		HttpGet request = new HttpGet(testURL);
+
+		HttpResponse response = client.execute(request);
+		assertEquals(501, response.getStatusLine().getStatusCode());
+		String content = IOUtils.toString(response.getEntity().getContent(), "UTF-8");
+		assertNotNull(content);
 	}
 
 }

--- a/src/test/java/com/gitblit/tests/GitServletTest.java
+++ b/src/test/java/com/gitblit/tests/GitServletTest.java
@@ -25,6 +25,11 @@ import java.util.Date;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.apache.commons.io.IOUtils;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.HttpClientBuilder;
 import org.eclipse.jgit.api.CloneCommand;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.MergeCommand.FastForwardMode;
@@ -928,4 +933,53 @@ public class GitServletTest extends GitblitUnitTest {
 		GitBlitSuite.close(repository);
 		assertTrue("Repository has an empty push log!", pushes.size() > 0);
 	}
+
+
+
+	@Test
+	public void testInvalidURLNoRepoName() throws IOException {
+		final String testURL = GitBlitSuite.gitServletUrl + "/?service=git-upload-pack";
+
+		HttpClient client = HttpClientBuilder.create().build();
+		HttpGet request = new HttpGet(testURL);
+
+		HttpResponse response = client.execute(request);
+		assertEquals("Expected BAD REQUEST due to missing repository string", 400, response.getStatusLine().getStatusCode());
+	}
+
+	@Test
+	public void testInvalidURLNoRepoName2() throws IOException {
+		final String testURL = GitBlitSuite.gitServletUrl + "//info/refs";
+
+		HttpClient client = HttpClientBuilder.create().build();
+		HttpGet request = new HttpGet(testURL);
+
+		HttpResponse response = client.execute(request);
+		assertEquals("Expected BAD REQUEST due to missing repository string", 400, response.getStatusLine().getStatusCode());
+	}
+
+
+	@Test
+	public void testURLUnknownRepo() throws IOException {
+		final String testURL = GitBlitSuite.url + "/r/foobar.git/info/refs";
+
+		HttpClient client = HttpClientBuilder.create().build();
+		HttpGet request = new HttpGet(testURL);
+
+		HttpResponse response = client.execute(request);
+		assertEquals(401, response.getStatusLine().getStatusCode());
+	}
+
+	@Test
+	public void testURLUnknownAction() throws IOException {
+		final String testURL = GitBlitSuite.gitServletUrl + "/helloworld.git/something/unknown";
+
+		HttpClient client = HttpClientBuilder.create().build();
+		HttpGet request = new HttpGet(testURL);
+
+		HttpResponse response = client.execute(request);
+
+		assertEquals(400, response.getStatusLine().getStatusCode());
+	}
+
 }


### PR DESCRIPTION
Fix the NPE when a request URL can not be properly parsed and no action is found.
While the clone.bundle command still is not implemented, at least it is detected and a more
helpful error message is returned.