### PR TITLE
Fix 1150: Use external link instead of internal wiki link

### DIFF
--- a/src/site/tickets_overview.mkd
+++ b/src/site/tickets_overview.mkd
@@ -35,7 +35,7 @@ Gitblit's ticket data is based on a ridiculously simple concept: a ticket is the
 
 All ticket services inherit from the same base class which handles most of the high level logic for ticket management including caching, milestones (stored in .git/config), indexing, queries, and searches.
 
-You can find descriptions of the available persistence services in [[tickets setup]].
+You can find descriptions of the available persistence services in [tickets setup](tickets_setup.html).
 
 #### Limitations
 


### PR DESCRIPTION
The `tickets_overview` page links to the `tickets_setup` page using a
wiki style internal link: `[[tickets setup]]`. Whatever library is
interpreting that is creating a link under the assumption that the
resulting page will be called `tickets-setup.html`. But that is not the
convention used by Moxie, which will use the source file name and thus
create a file called `tickets_setup.html`.

I was not able to find out which of the many libraries included is the
one that parses this file and creates the link. Messy.

There are two solutions. One is to configure the Moxie site build to
generate the file as `tickets-setup.html`. But this would break any
links to that page that might exist somewhere on the Interweb. So I
opted for the other option, which is to not use wiki syntax for the
reference to the local page but normal markdown syntax. This is not
a wiki, afterall.

This fixes issue #1150.