### PR TITLE
Fix CPU hog in config save for large users.conf

### DIFF
--- a/src/main/java/com/gitblit/ConfigUserService.java
+++ b/src/main/java/com/gitblit/ConfigUserService.java
@@ -676,7 +676,7 @@ public class ConfigUserService implements IUserService {
 		// Write a temporary copy of the users file
 		File realmFileCopy = new File(realmFile.getAbsolutePath() + ".tmp");
 
-		StoredConfig config = new FileBasedConfig(realmFileCopy, FS.detect());
+		StoredUserConfig config = new StoredUserConfig(realmFileCopy);
 
 		// write users
 		for (UserModel model : users.values()) {

--- a/src/main/java/com/gitblit/StoredUserConfig.java
+++ b/src/main/java/com/gitblit/StoredUserConfig.java
@@ -1,0 +1,172 @@
+package com.gitblit;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.function.Function;
+
+/**
+ * Simple class with the only purpose to save the realm file (users.conf) in
+ * a fast efficient manner. The JGit Config classes used previously caused
+ * a massive CPU hog if the users file got bigger than about 30000 lines.
+ *
+ * @author Ingo Lafrenz
+ *
+ */
+public class StoredUserConfig {
+
+	private final File realmFileCopy;
+	private SortedMap<String, Section> sections = new TreeMap<>();
+
+	public StoredUserConfig(File realmFileCopy) {
+		this.realmFileCopy = realmFileCopy;
+	}
+
+	public void setString(final String section, final String subsection, String name, String value) {
+		Section s = sections.computeIfAbsent(generateKey(section, subsection), new Function<String, Section>() {
+			@Override
+			public Section apply(String k) {
+				return new Section(section, subsection);
+			}
+		});
+		s.addEntry(name, value);
+	}
+
+	public void setBoolean(String section, String subsection, String name, boolean value) {
+		setString(section, subsection, name, String.valueOf(value));
+	}
+
+	public void setStringList(String section, String subsection, String name, List<String> list) {
+		for (String value : list) {
+			setString(section, subsection, name, value);
+		}
+	}
+
+	public void save() throws IOException {
+		try (FileWriter fileWriter = new FileWriter(realmFileCopy);
+				PrintWriter printWriter = new PrintWriter(fileWriter);) {
+			for (Map.Entry<String,Section> entry : sections.entrySet()) {
+				writeSection(printWriter, entry.getKey(), entry.getValue());
+			}
+		}
+	}
+
+	private static void writeSection(PrintWriter printWriter, String key, Section section) {
+		printWriter.printf("[%s \"%s\"]\n", section.getName(), section.getSubSection());
+		for (Entry entry : section.getEntries().values()) {
+			writeEntry(printWriter, entry.getKey(), entry.getValue());
+		}
+	}
+
+	private static void writeEntry(PrintWriter printWriter, String key, String value) {
+		printWriter.printf("\t%s = %s\n", key, escape(value));
+	}
+
+	private static String escape(String value) {
+		String fixedValue = '#' == value.charAt(0) ? "\"" + value + "\"" : value;
+		fixedValue = fixedValue.replace("\\", "\\\\");
+		return fixedValue;
+	}
+
+	private static String generateKey(String key, String subKey) {
+		return "k:" + key + "s:" + subKey;
+	}
+
+	private static class Section {
+		private final String name;
+		private final String subSection;
+		private final SortedMap<String, Entry> entries = new TreeMap<>();
+
+		public Section(String name, String subSection) {
+			this.name = name;
+			this.subSection = subSection;
+		}
+
+		public void addEntry(final String key, final String value) {
+			entries.put(generateKey(key, value), new Entry(key, value));
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public String getSubSection() {
+			return subSection;
+		}
+
+		public SortedMap<String, Entry> getEntries() {
+			return entries;
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(name, subSection);
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (this == obj)
+				return true;
+			if (obj == null)
+				return false;
+			if (getClass() != obj.getClass())
+				return false;
+			Section other = (Section) obj;
+			return Objects.equals(name, other.name) && Objects.equals(subSection, other.subSection);
+		}
+
+		@Override
+		public String toString() {
+			return String.format("Section [name=%s, subSection=%s]", name, subSection);
+		}
+
+	}
+
+	private static class Entry {
+		private final String key;
+		private final String value;
+
+		public Entry(String key, String value) {
+			this.key = key;
+			this.value = value;
+		}
+
+		public String getKey() {
+			return key;
+		}
+
+		public String getValue() {
+			return value;
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(key, value);
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (this == obj)
+				return true;
+			if (obj == null)
+				return false;
+			if (getClass() != obj.getClass())
+				return false;
+			Entry other = (Entry) obj;
+			return Objects.equals(key, other.key) && Objects.equals(value, other.value);
+		}
+
+		@Override
+		public String toString() {
+			return String.format("Entry [key=%s, value=%s]", key, value);
+		}
+
+	}
+
+}


### PR DESCRIPTION
If the realm file (users.conf) exceeds a certain size (about 30000 lines) saving this file causes a massive CPU hog. I have provided a branch that demonstrates the issue:
https://github.com/Curly060/gitblit/tree/show-user-config-save-cpu-hog-bug
https://github.com/gitblit/gitblit/compare/master...Curly060:show-user-config-save-cpu-hog-bug

So simply check out this branch and run the ConfigUserService class from there. But beware: Depending on the CPU you have, this might take from 20s up to several minutes!

This patch here simply replaces the usage of JGits Config classes with a much more efficient and far more simple class.

I know that Gitblit was not made for big workgroups and clearly this is a big users.conf. Nevertheless, saving 60000 lines should not hog a CPU like that.