### PR TITLE
Modified Batch file for Windows, if it's called directly

### DIFF
--- a/src/main/distrib/win/gitblit-stop.cmd
+++ b/src/main/distrib/win/gitblit-stop.cmd
@@ -2,4 +2,4 @@
 
 SET CD=%~dp0
 SET CD=%CD:~0,-1%
-java -cp gitblit.jar;"%CD%\ext\*" com.gitblit.GitBlitServer --stop --baseFolder data %*
+java -cp "%CD%\gitblit.jar";"%CD%\ext\*" com.gitblit.GitBlitServer --stop --baseFolder data %*

--- a/src/main/distrib/win/gitblit-stop.cmd
+++ b/src/main/distrib/win/gitblit-stop.cmd
@@ -1,1 +1,5 @@
-@java -cp gitblit.jar;"%CD%\ext\*" com.gitblit.GitBlitServer --stop --baseFolder data %*
+@ECHO OFF
+
+SET CD=%~dp0
+SET CD=%CD:~0,-1%
+java -cp gitblit.jar;"%CD%\ext\*" com.gitblit.GitBlitServer --stop --baseFolder data %*

--- a/src/main/distrib/win/gitblit.cmd
+++ b/src/main/distrib/win/gitblit.cmd
@@ -1,1 +1,5 @@
-@java -cp gitblit.jar;"%CD%\ext\*" com.gitblit.GitBlitServer --baseFolder data %*
+@ECHO OFF
+
+SET CD=%~dp0
+SET CD=%CD:~0,-1%
+java -cp "%CD%\gitblit.jar";"%CD%\ext\*" com.gitblit.GitBlitServer --baseFolder data %*

--- a/src/main/distrib/win/installService.cmd
+++ b/src/main/distrib/win/installService.cmd
@@ -1,3 +1,5 @@
+@ECHO OFF
+
 @REM Install Gitblit as a Windows service.
 
 @REM gitblitw.exe (prunmgr.exe) is a GUI application for monitoring 
@@ -10,6 +12,8 @@
 
 @REM arch = x86, amd64, or ia32
 SET ARCH=amd64
+SET CD=%~dp0
+SET CD=%CD:~0,-1%
 
 @REM Be careful not to introduce trailing whitespace after the ^ characters.
 @REM Use ; or # to separate values in the --StartParams parameter.

--- a/src/main/distrib/win/reindex-tickets.cmd
+++ b/src/main/distrib/win/reindex-tickets.cmd
@@ -1,3 +1,5 @@
+@ECHO OFF
+
 @REM --------------------------------------------------------------------------
 @REM This is for reindexing Tickets with Lucene.
 @REM
@@ -8,15 +10,19 @@
 @REM     reindex-tickets <baseFolder>
 @REM
 @REM --------------------------------------------------------------------------
-@if [%1]==[] goto nobasefolder
 
-@java -cp gitblit.jar;"%CD%\ext\*" com.gitblit.ReindexTickets --baseFolder %1
-@goto end
+SET CD=%~dp0
+SET CD=%CD:~0,-1%
+
+if [%1]==[] goto nobasefolder
+
+java -cp gitblit.jar;"%CD%\ext\*" com.gitblit.ReindexTickets --baseFolder %1
+goto end
 
 :nobasefolder
-@echo "Please specify your baseFolder!"
-@echo
-@echo "    reindex-tickets c:/gitblit-data"
-@echo
+echo "Please specify your baseFolder!"
+echo
+echo "    reindex-tickets c:/gitblit-data"
+echo
 
 :end

--- a/src/main/distrib/win/uninstallService.cmd
+++ b/src/main/distrib/win/uninstallService.cmd
@@ -1,5 +1,9 @@
+@ECHO OFF
+
 @REM arch = x86, amd64, or ia32
 SET ARCH=amd64
+SET CD=%~dp0
+SET CD=%CD:~0,-1%
 
 @REM Delete the gitblit service
 "%CD%\%ARCH%\gitblit.exe" //DS//gitblit


### PR DESCRIPTION
I was tricked by the first install and clicked on my Windows 10 on the gitblit.cmd and nothing happens. I looked into it and a environment Variable "CD" is used, but never set. I modified the batch file, so the current directory of the batch file is used as root folder for the classpath. So it worked without anything else to modify.

So nothing like set up a environment variable is needed.