### PR TITLE
raw: URL encode the links to raw view of files

### DIFF
--- a/src/main/java/com/gitblit/servlet/RawServlet.java
+++ b/src/main/java/com/gitblit/servlet/RawServlet.java
@@ -36,6 +36,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.tika.Tika;
+import org.apache.wicket.protocol.http.WicketURLEncoder;
 import org.eclipse.jgit.lib.FileMode;
 import org.eclipse.jgit.lib.MutableObjectId;
 import org.eclipse.jgit.lib.ObjectLoader;
@@ -121,7 +122,8 @@ public class RawServlet extends HttpServlet {
 			path = path.substring(1);
 		}
 		String encodedPath = path == null ? "" : path.replace('/', fsc);
-		return baseURL + Constants.RAW_PATH + repository + "/" + (branch == null ? "" : (branch + "/" + encodedPath));
+		String fullPath = repository + "/" + (branch == null ? "" : (branch + "/" + encodedPath));
+		return baseURL + Constants.RAW_PATH + WicketURLEncoder.FULL_PATH_INSTANCE.encode(fullPath);
 	}
 
 


### PR DESCRIPTION
This still needs to be tested in a Tomcat. So far only checked with Gitblit GO.