### PR TITLE
Fixes what was broken due to #1358 issue fix.

### DIFF
--- a/src/main/java/com/gitblit/wicket/MarkupProcessor.java
+++ b/src/main/java/com/gitblit/wicket/MarkupProcessor.java
@@ -360,22 +360,22 @@ public class MarkupProcessor {
 
 			@Override
 			public Rendering render(ExpLinkNode node, String text) {
-				//Relative file-like MD links needs to be re-mapped to be relative to 
-				//repository name so that they display correctly sub-folder files
-				//Absolute links must be left un-touched.
+				// Relative file-like MD links needs to be re-mapped to be relative to 
+				// repository name so that they display correctly sub-folder files
+				// Absolute links must be left un-touched.
 				
-				//Note: The absolute lack of comments in ExpLinkNode is... well...
-				//I assume, that getRelativePath is handling "file like" links
-				//linke "/xx/tt"  or "../somefolder". What needs to be captured it
-				//is a full URL link. The easiest is to ask java to parse URL
-				//and let it fail. Shame java.net.URL has no method to validate URL without
-				//throwing.
-				try{
+				// Note: The absolute lack of comments in ExpLinkNode is... well...
+				// I assume, that getRelativePath is handling "file like" links
+				// like "/xx/tt"  or "../somefolder". What needs to be captured
+				// is a full URL link. The easiest is to ask java to parse URL
+				// and let it fail. Shame java.net.URL has no method to validate URL without
+				// throwing.
+				try {
 					new java.net.URL(node.url);
-					//This is URL, fallback to superclass.
+					// This is URL, fallback to superclass.
 					return super.render(node,text);
-				}catch(java.net.MalformedURLException ex){};
-				//Now this is surely not an URL.
+				} catch (java.net.MalformedURLException ignored) {};
+				// repository-relative link
 				String path = doc.getRelativePath(node.url);
 				String url = getWicketUrl(DocPage.class, repositoryName, commitId, path);
 				return new Rendering(url, text);

--- a/src/main/java/com/gitblit/wicket/MarkupProcessor.java
+++ b/src/main/java/com/gitblit/wicket/MarkupProcessor.java
@@ -360,6 +360,22 @@ public class MarkupProcessor {
 
 			@Override
 			public Rendering render(ExpLinkNode node, String text) {
+				//Relative file-like MD links needs to be re-mapped to be relative to 
+				//repository name so that they display correctly sub-folder files
+				//Absolute links must be left un-touched.
+				
+				//Note: The absolute lack of comments in ExpLinkNode is... well...
+				//I assume, that getRelativePath is handling "file like" links
+				//linke "/xx/tt"  or "../somefolder". What needs to be captured it
+				//is a full URL link. The easiest is to ask java to parse URL
+				//and let it fail. Shame java.net.URL has no method to validate URL without
+				//throwing.
+				try{
+					new java.net.URL(node.url);
+					//This is URL, fallback to superclass.
+					return super.render(node,text);
+				}catch(java.net.MalformedURLException ex){};
+				//Now this is surely not an URL.
 				String path = doc.getRelativePath(node.url);
 				String url = getWicketUrl(DocPage.class, repositoryName, commitId, path);
 				return new Rendering(url, text);


### PR DESCRIPTION
This commit fixes what was broken in commit
https://github.com/gitblit/gitblit/commit/b23269acc0f460f583311c679d751925b8402563
due to #1358 issue

No automatic test were included, no regression tests were run.

Manual test scenario

A. Bug presentation

1. Pull b23269acc0f460f583311c679d751925b8402563, compile and start GO server.
2. Create repository with readme.md file and x.md file.
3. In readme.md place link to x.md using relative syntax (x)[x.md] and (xx)[http://google.com] absolute link.
4. Push repository to server.
5. Get to repository page, see docs and observe links. The relative link is processed correctly but absolute link is escaped with % syntax and appended to repository path effectively breaking it.

Expected result: 
1.Relative link works as in test
2.Absolute link works correctly pointing to specified site.

B. Fix presentation
1. Pull this branch, compile and start GO server
2. Do the test again.
3. Observe correct results.