### PR TITLE
Update SSHD to version 1.7.0 and add support for EdDSA user keys

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -55,7 +55,7 @@
 	<classpathentry kind="lib" path="ext/bcmail-jdk15on-1.57.jar" sourcepath="ext/src/bcmail-jdk15on-1.57.jar" />
 	<classpathentry kind="lib" path="ext/bcpkix-jdk15on-1.57.jar" sourcepath="ext/src/bcpkix-jdk15on-1.57.jar" />
 	<classpathentry kind="lib" path="ext/eddsa-0.2.0.jar" sourcepath="ext/src/eddsa-0.2.0.jar" />
-	<classpathentry kind="lib" path="ext/sshd-core-1.6.0.jar" sourcepath="ext/src/sshd-core-1.6.0.jar" />
+	<classpathentry kind="lib" path="ext/sshd-core-1.7.0.jar" sourcepath="ext/src/sshd-core-1.7.0.jar" />
 	<classpathentry kind="lib" path="ext/mina-core-2.0.21.jar" sourcepath="ext/src/mina-core-2.0.21.jar" />
 	<classpathentry kind="lib" path="ext/rome-0.9.jar" sourcepath="ext/src/rome-0.9.jar" />
 	<classpathentry kind="lib" path="ext/jdom-1.0.jar" sourcepath="ext/src/jdom-1.0.jar" />

--- a/.classpath
+++ b/.classpath
@@ -54,7 +54,8 @@
 	<classpathentry kind="lib" path="ext/bcprov-jdk15on-1.57.jar" sourcepath="ext/src/bcprov-jdk15on-1.57.jar" />
 	<classpathentry kind="lib" path="ext/bcmail-jdk15on-1.57.jar" sourcepath="ext/src/bcmail-jdk15on-1.57.jar" />
 	<classpathentry kind="lib" path="ext/bcpkix-jdk15on-1.57.jar" sourcepath="ext/src/bcpkix-jdk15on-1.57.jar" />
-	<classpathentry kind="lib" path="ext/sshd-core-1.2.0.jar" sourcepath="ext/src/sshd-core-1.2.0.jar" />
+	<classpathentry kind="lib" path="ext/eddsa-0.2.0.jar" sourcepath="ext/src/eddsa-0.2.0.jar" />
+	<classpathentry kind="lib" path="ext/sshd-core-1.6.0.jar" sourcepath="ext/src/sshd-core-1.6.0.jar" />
 	<classpathentry kind="lib" path="ext/mina-core-2.0.21.jar" sourcepath="ext/src/mina-core-2.0.21.jar" />
 	<classpathentry kind="lib" path="ext/rome-0.9.jar" sourcepath="ext/src/rome-0.9.jar" />
 	<classpathentry kind="lib" path="ext/jdom-1.0.jar" sourcepath="ext/src/jdom-1.0.jar" />

--- a/build.moxie
+++ b/build.moxie
@@ -114,7 +114,7 @@ properties: {
   bouncycastle.version : 1.57
   selenium.version : 2.28.0
   wikitext.version : 1.4
-  sshd.version: 1.6.0
+  sshd.version: 1.7.0
   mina.version: 2.0.21
   guice.version : 4.0
   # Gitblit maintains a fork of guice-servlet

--- a/build.moxie
+++ b/build.moxie
@@ -114,7 +114,7 @@ properties: {
   bouncycastle.version : 1.57
   selenium.version : 2.28.0
   wikitext.version : 1.4
-  sshd.version: 1.2.0
+  sshd.version: 1.6.0
   mina.version: 2.0.21
   guice.version : 4.0
   # Gitblit maintains a fork of guice-servlet
@@ -163,6 +163,7 @@ dependencies:
 - compile 'org.bouncycastle:bcprov-jdk15on:${bouncycastle.version}' :war
 - compile 'org.bouncycastle:bcmail-jdk15on:${bouncycastle.version}' :war
 - compile 'org.bouncycastle:bcpkix-jdk15on:${bouncycastle.version}' :war
+- compile 'net.i2p.crypto:eddsa:0.2.0' :war !org.easymock
 - compile 'org.apache.sshd:sshd-core:${sshd.version}' :war !org.easymock
 - compile 'org.apache.mina:mina-core:${mina.version}' :war !org.easymock
 - compile 'rome:rome:0.9' :war :manager :api

--- a/gitblit.iml
+++ b/gitblit.iml
@@ -552,13 +552,13 @@
       </library>
     </orderEntry>
     <orderEntry type="module-library">
-      <library name="sshd-core-1.6.0.jar">
+      <library name="sshd-core-1.7.0.jar">
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/ext/sshd-core-1.6.0.jar!/" />
+          <root url="jar://$MODULE_DIR$/ext/sshd-core-1.7.0.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/ext/src/sshd-core-1.6.0.jar!/" />
+          <root url="jar://$MODULE_DIR$/ext/src/sshd-core-1.7.0.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>

--- a/gitblit.iml
+++ b/gitblit.iml
@@ -541,13 +541,24 @@
       </library>
     </orderEntry>
     <orderEntry type="module-library">
-      <library name="sshd-core-1.2.0.jar">
+      <library name="eddsa-0.2.0.jar">
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/ext/sshd-core-1.2.0.jar!/" />
+          <root url="jar://$MODULE_DIR$/ext/eddsa-0.2.0.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/ext/src/sshd-core-1.2.0.jar!/" />
+          <root url="jar://$MODULE_DIR$/ext/src/eddsa-0.2.0.jar!/" />
+        </SOURCES>
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library">
+      <library name="sshd-core-1.6.0.jar">
+        <CLASSES>
+          <root url="jar://$MODULE_DIR$/ext/sshd-core-1.6.0.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES>
+          <root url="jar://$MODULE_DIR$/ext/src/sshd-core-1.6.0.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>

--- a/src/main/java/com/gitblit/transport/ssh/FileKeyPairProvider.java
+++ b/src/main/java/com/gitblit/transport/ssh/FileKeyPairProvider.java
@@ -26,7 +26,7 @@ import java.util.Iterator;
 import java.util.NoSuchElementException;
 
 import org.apache.sshd.common.keyprovider.AbstractKeyPairProvider;
-import org.apache.sshd.common.util.SecurityUtils;
+import org.apache.sshd.common.util.security.SecurityUtils;
 import org.bouncycastle.openssl.PEMDecryptorProvider;
 import org.bouncycastle.openssl.PEMEncryptedKeyPair;
 import org.bouncycastle.openssl.PEMKeyPair;

--- a/src/main/java/com/gitblit/transport/ssh/NonForwardingFilter.java
+++ b/src/main/java/com/gitblit/transport/ssh/NonForwardingFilter.java
@@ -21,23 +21,23 @@ import org.apache.sshd.server.forward.ForwardingFilter;
 
 public class NonForwardingFilter implements ForwardingFilter {
 
-	@Override
-	public boolean canConnect(Type type, SshdSocketAddress address, Session session) {
-		return false;
-	}
+    @Override
+    public boolean canConnect(Type type, SshdSocketAddress address, Session session) {
+        return false;
+    }
 
-	@Override
-	public boolean canForwardAgent(Session session) {
-		return false;
-	}
+    @Override
+    public boolean canForwardAgent(Session session, String requestType) {
+        return false;
+    }
 
-	@Override
-	public boolean canForwardX11(Session session) {
-		return false;
-	}
+    @Override
+    public boolean canForwardX11(Session session, String requestType) {
+        return false;
+    }
 
-	@Override
-	public boolean canListen(SshdSocketAddress address, Session session) {
-		return false;
-	}
+    @Override
+    public boolean canListen(SshdSocketAddress address, Session session) {
+        return false;
+    }
 }

--- a/src/main/java/com/gitblit/transport/ssh/SshDaemon.java
+++ b/src/main/java/com/gitblit/transport/ssh/SshDaemon.java
@@ -95,10 +95,13 @@ public class SshDaemon {
 
 		// Ensure that Bouncy Castle is our JCE provider
 		SecurityUtils.registerSecurityProvider(new BouncyCastleSecurityProviderRegistrar());
-		// Add support for ED25519_SHA512
-		SecurityUtils.registerSecurityProvider(new EdDSASecurityProviderRegistrar());
 		if (SecurityUtils.isBouncyCastleRegistered()) {
 			log.info("BouncyCastle is registered as a JCE provider");
+		}
+		// Add support for ED25519_SHA512
+		SecurityUtils.registerSecurityProvider(new EdDSASecurityProviderRegistrar());
+		if (SecurityUtils.isProviderRegistered("EdDSA")) {
+			log.info("EdDSA is registered as a JCE provider");
 		}
 
 		// Generate host RSA and DSA keypairs and create the host keypair provider
@@ -164,7 +167,7 @@ public class SshDaemon {
 
 		sshd.setSessionFactory(new SshServerSessionFactory(sshd));
 		sshd.setFileSystemFactory(new DisabledFilesystemFactory());
-		sshd.setTcpipForwardingFilter(new NonForwardingFilter());
+		sshd.setForwardingFilter(new NonForwardingFilter());
 		sshd.setCommandFactory(new SshCommandFactory(gitblit, workQueue));
 		sshd.setShellFactory(new WelcomeShell(gitblit));
 

--- a/src/main/java/com/gitblit/transport/ssh/SshDaemon.java
+++ b/src/main/java/com/gitblit/transport/ssh/SshDaemon.java
@@ -29,7 +29,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.sshd.common.io.IoServiceFactoryFactory;
 import org.apache.sshd.common.io.mina.MinaServiceFactoryFactory;
 import org.apache.sshd.common.io.nio2.Nio2ServiceFactoryFactory;
-import org.apache.sshd.common.util.SecurityUtils;
+import org.apache.sshd.common.util.security.SecurityUtils;
+import org.apache.sshd.common.util.security.bouncycastle.BouncyCastleSecurityProviderRegistrar;
+import org.apache.sshd.common.util.security.eddsa.EdDSASecurityProviderRegistrar;
 import org.apache.sshd.server.SshServer;
 import org.apache.sshd.server.auth.pubkey.CachingPublicKeyAuthenticator;
 import org.bouncycastle.openssl.PEMWriter;
@@ -92,9 +94,11 @@ public class SshDaemon {
 		IStoredSettings settings = gitblit.getSettings();
 
 		// Ensure that Bouncy Castle is our JCE provider
-		SecurityUtils.setRegisterBouncyCastle(true);
+		SecurityUtils.registerSecurityProvider(new BouncyCastleSecurityProviderRegistrar());
+		// Add support for ED25519_SHA512
+		SecurityUtils.registerSecurityProvider(new EdDSASecurityProviderRegistrar());
 		if (SecurityUtils.isBouncyCastleRegistered()) {
-			log.debug("BouncyCastle is registered as a JCE provider");
+			log.info("BouncyCastle is registered as a JCE provider");
 		}
 
 		// Generate host RSA and DSA keypairs and create the host keypair provider

--- a/src/main/java/com/gitblit/transport/ssh/WelcomeShell.java
+++ b/src/main/java/com/gitblit/transport/ssh/WelcomeShell.java
@@ -57,6 +57,11 @@ public class WelcomeShell implements Factory<Command> {
 		return new SendMessage(gitblit);
 	}
 
+	@Override
+	public Command get() {
+		return create();
+	}
+
 	private static class SendMessage implements Command, SessionAware {
 
 		private final IPublicKeyManager km;

--- a/src/test/java/com/gitblit/tests/LdapPublicKeyManagerTest.java
+++ b/src/test/java/com/gitblit/tests/LdapPublicKeyManagerTest.java
@@ -28,7 +28,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.sshd.common.util.SecurityUtils;
+import org.apache.sshd.common.util.security.SecurityUtils;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/src/test/java/com/gitblit/tests/SshUnitTest.java
+++ b/src/test/java/com/gitblit/tests/SshUnitTest.java
@@ -36,7 +36,7 @@ import org.apache.sshd.client.future.AuthFuture;
 import org.apache.sshd.client.keyverifier.ServerKeyVerifier;
 import org.apache.sshd.client.session.ClientSession;
 import org.apache.sshd.common.config.keys.FilePasswordProvider;
-import org.apache.sshd.common.util.SecurityUtils;
+import org.apache.sshd.common.util.security.SecurityUtils;
 import org.eclipse.jgit.lib.Config;
 import org.eclipse.jgit.storage.file.FileBasedConfig;
 import org.eclipse.jgit.util.FS;


### PR DESCRIPTION
This PR adds the second commit from PR #1272, adding EdDSA support for user keys.
MINA SSHD is increased to version 1.7.0, the last version before larger reorganisation. So the next dependency version update to the latest version will be done in a separate PR.

Merging this PR will finally close #1272 as done.