### PR TITLE
Update Guice version to 5.1.0

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -6,11 +6,18 @@
 	<classpathentry kind="src" path="src/test/bugtraq" output="bin/test-classes" />
 	<classpathentry kind="src" path="src/main/resources" />
 	<classpathentry kind="src" path="src/test/resources" output="bin/test-classes" />
-	<classpathentry kind="lib" path="ext/guice-4.0.jar" sourcepath="ext/src/guice-4.0.jar" />
+	<classpathentry kind="lib" path="ext/guice-5.1.0.jar" sourcepath="ext/src/guice-5.1.0.jar" />
 	<classpathentry kind="lib" path="ext/javax.inject-1.jar" sourcepath="ext/src/javax.inject-1.jar" />
 	<classpathentry kind="lib" path="ext/aopalliance-1.0.jar" sourcepath="ext/src/aopalliance-1.0.jar" />
-	<classpathentry kind="lib" path="ext/guava-18.0.jar" sourcepath="ext/src/guava-18.0.jar" />
-	<classpathentry kind="lib" path="ext/guice-servlet-4.0-gb2.jar" sourcepath="ext/src/guice-servlet-4.0-gb2.jar" />
+	<classpathentry kind="lib" path="ext/guava-27.0.1-jre.jar" sourcepath="ext/src/guava-27.0.1-jre.jar" />
+	<classpathentry kind="lib" path="ext/failureaccess-1.0.1.jar" sourcepath="ext/src/failureaccess-1.0.1.jar" />
+	<classpathentry kind="lib" path="ext/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar" />
+	<classpathentry kind="lib" path="ext/jsr305-3.0.2.jar" sourcepath="ext/src/jsr305-3.0.2.jar" />
+	<classpathentry kind="lib" path="ext/checker-qual-2.5.2.jar" sourcepath="ext/src/checker-qual-2.5.2.jar" />
+	<classpathentry kind="lib" path="ext/error_prone_annotations-2.2.0.jar" sourcepath="ext/src/error_prone_annotations-2.2.0.jar" />
+	<classpathentry kind="lib" path="ext/j2objc-annotations-1.1.jar" sourcepath="ext/src/j2objc-annotations-1.1.jar" />
+	<classpathentry kind="lib" path="ext/guice-servlet-5.1.0-gb2.jar" sourcepath="ext/src/guice-servlet-5.1.0-gb2.jar" />
+	<classpathentry kind="lib" path="ext/animal-sniffer-annotations-1.17.jar" sourcepath="ext/src/animal-sniffer-annotations-1.17.jar" />
 	<classpathentry kind="lib" path="ext/annotations-12.0.jar" sourcepath="ext/src/annotations-12.0.jar" />
 	<classpathentry kind="lib" path="ext/log4j-1.2.17.jar" sourcepath="ext/src/log4j-1.2.17.jar" />
 	<classpathentry kind="lib" path="ext/slf4j-api-1.7.29.jar" sourcepath="ext/src/slf4j-api-1.7.29.jar" />

--- a/build.moxie
+++ b/build.moxie
@@ -116,9 +116,9 @@ properties: {
   wikitext.version : 1.4
   sshd.version: 1.7.0
   mina.version: 2.0.21
-  guice.version : 4.0
+  guice.version : 5.1.0
   # Gitblit maintains a fork of guice-servlet
-  guice-servlet.version : 4.0-gb2
+  guice-servlet.version : 5.1.0-gb2
   }
 
 # Dependencies
@@ -135,7 +135,7 @@ properties: {
 dependencies:
 - compile 'com.google.inject:guice:${guice.version}' :war :fedclient
 - compile 'com.google.inject.extensions:guice-servlet:${guice-servlet.version}' :war
-- compile 'com.google.guava:guava:18.0' :war :fedclient
+- compile 'com.google.guava:guava:27.0.1-jre' :war :fedclient
 - compile 'com.intellij:annotations:12.0' :war
 - compile 'log4j:log4j:1.2.17' :war :fedclient :manager
 - compile 'org.slf4j:slf4j-api:${slf4j.version}' :war :fedclient :manager

--- a/gitblit.iml
+++ b/gitblit.iml
@@ -15,13 +15,13 @@
     </content>
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="module-library">
-      <library name="guice-4.0.jar">
+      <library name="guice-5.1.0.jar">
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/ext/guice-4.0.jar!/" />
+          <root url="jar://$MODULE_DIR$/ext/guice-5.1.0.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/ext/src/guice-4.0.jar!/" />
+          <root url="jar://$MODULE_DIR$/ext/src/guice-5.1.0.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
@@ -48,24 +48,99 @@
       </library>
     </orderEntry>
     <orderEntry type="module-library">
-      <library name="guava-18.0.jar">
+      <library name="guava-27.0.1-jre.jar">
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/ext/guava-18.0.jar!/" />
+          <root url="jar://$MODULE_DIR$/ext/guava-27.0.1-jre.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/ext/src/guava-18.0.jar!/" />
+          <root url="jar://$MODULE_DIR$/ext/src/guava-27.0.1-jre.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library">
-      <library name="guice-servlet-4.0-gb2.jar">
+      <library name="failureaccess-1.0.1.jar">
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/ext/guice-servlet-4.0-gb2.jar!/" />
+          <root url="jar://$MODULE_DIR$/ext/failureaccess-1.0.1.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/ext/src/guice-servlet-4.0-gb2.jar!/" />
+          <root url="jar://$MODULE_DIR$/ext/src/failureaccess-1.0.1.jar!/" />
+        </SOURCES>
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library">
+      <library name="listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar">
+        <CLASSES>
+          <root url="jar://$MODULE_DIR$/ext/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library">
+      <library name="jsr305-3.0.2.jar">
+        <CLASSES>
+          <root url="jar://$MODULE_DIR$/ext/jsr305-3.0.2.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES>
+          <root url="jar://$MODULE_DIR$/ext/src/jsr305-3.0.2.jar!/" />
+        </SOURCES>
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library">
+      <library name="checker-qual-2.5.2.jar">
+        <CLASSES>
+          <root url="jar://$MODULE_DIR$/ext/checker-qual-2.5.2.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES>
+          <root url="jar://$MODULE_DIR$/ext/src/checker-qual-2.5.2.jar!/" />
+        </SOURCES>
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library">
+      <library name="error_prone_annotations-2.2.0.jar">
+        <CLASSES>
+          <root url="jar://$MODULE_DIR$/ext/error_prone_annotations-2.2.0.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES>
+          <root url="jar://$MODULE_DIR$/ext/src/error_prone_annotations-2.2.0.jar!/" />
+        </SOURCES>
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library">
+      <library name="j2objc-annotations-1.1.jar">
+        <CLASSES>
+          <root url="jar://$MODULE_DIR$/ext/j2objc-annotations-1.1.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES>
+          <root url="jar://$MODULE_DIR$/ext/src/j2objc-annotations-1.1.jar!/" />
+        </SOURCES>
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library">
+      <library name="guice-servlet-5.1.0-gb2.jar">
+        <CLASSES>
+          <root url="jar://$MODULE_DIR$/ext/guice-servlet-5.1.0-gb2.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES>
+          <root url="jar://$MODULE_DIR$/ext/src/guice-servlet-5.1.0-gb2.jar!/" />
+        </SOURCES>
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library">
+      <library name="animal-sniffer-annotations-1.17.jar">
+        <CLASSES>
+          <root url="jar://$MODULE_DIR$/ext/animal-sniffer-annotations-1.17.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES>
+          <root url="jar://$MODULE_DIR$/ext/src/animal-sniffer-annotations-1.17.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>

--- a/releases.moxie
+++ b/releases.moxie
@@ -17,6 +17,8 @@ r34: {
     additions: ~
     dependencyChanges:
       - update to JavaMail 1.5.6 (pr-1217 by @paladox)
+      - update Google Guice to 5.1.0
+      - update Google Guava to 27.0.1-jre
     contributors:
       - paladox
 }


### PR DESCRIPTION
Update Guice to 5.1.0. This version is compatible with Java 17. The gitblit patch of the servlet extension was ported to Guice 5.1.0, too.

This contributes one step towards Java 17 compatibility, asked for in issue #1420.
In order to not spread the issue on Java 17 compatibility over multiple issues, and since this updates fixes the problem visible in the log in issue 1373, this PR closes issue #1373.