### PR TITLE
Fix crash in Gitblit Authority for deleted users

### DIFF
--- a/releases.moxie
+++ b/releases.moxie
@@ -11,7 +11,8 @@ r34: {
     html: ~
     text: ~
     security: ~
-    fixes: ~
+    fixes:
+      - Fix crash in Gitblit Authority when users were deleted from Gitblit but still had entries (certificates) in the Authority.
     changes:
       - Minimum Java required increased to Java 8
     additions: ~

--- a/src/main/java/com/gitblit/authority/GitblitAuthority.java
+++ b/src/main/java/com/gitblit/authority/GitblitAuthority.java
@@ -299,7 +299,11 @@ public class GitblitAuthority extends JFrame implements X509Log {
 					List<UserCertificateModel> list = UserCertificateConfig.KEY.parse(config).list;
 					for (UserCertificateModel ucm : list) {
 						ucm.user = userService.getUserModel(ucm.user.username);
-						map.put(ucm.user.username, ucm);
+						// Users may have been deleted, but are still present in authority.conf.
+						// TODO: Currently this only keeps the app from crashing. It should provide means to show obsolete user entries and delete them.
+						if (ucm.user != null) {
+							map.put(ucm.user.username, ucm);
+						}
 					}
 				} catch (IOException e) {
 					e.printStackTrace();


### PR DESCRIPTION
When a user had a certificate, i.e. an entry in the Gitblit Authority database, but the user was deleted from the Gitblit database, then the Authority application crashes upon loading. This patch prevents the crash. The deleted user is no longer shown in the Authority. But the database entry still is kept. This should be improved to show deleted users and give the possibility to delete them from the Authority's database.

This fixes #1359